### PR TITLE
HelpOutLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.3.1
+* Save-MarkdownHelp:  
+  * Can now -ReplaceLink (Fixes #66)
+  * -ReplaceLink will always replace -OutputPath (Fixes #67)
+  * Changing Aliases for -SkipCommandType (Fixes #65)
+---
+
 ### 0.3:
 * Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
 * Workflow improvements:  Building formatting / types in CI/CD (#63)

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -8,7 +8,7 @@
       <maml:description>
         <maml:para>Gets MAML help</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets help for a given command, as MAML (Microsoft Assistance Markup Language) xml.</maml:para>
@@ -400,7 +400,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Gets Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets Help for a given command, in Markdown</maml:para>
@@ -609,7 +609,7 @@ If not provided, this will be the order they are defined in the formatter.</maml
       <maml:description>
         <maml:para>Gets a script's references</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the external references of a given PowerShell command.  These are the commands the script calls, and the types the script uses.</maml:para>
@@ -735,7 +735,7 @@ If not provided, this will be the order they are defined in the formatter.</maml
       <maml:description>
         <maml:para>Gets a Script's story</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the Script's "Story"</maml:para>
@@ -898,7 +898,7 @@ If not provided, this will be the order they are defined in the formatter.</maml
       <maml:description>
         <maml:para>Installs MAML into a module</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Installs MAML into a module.  </maml:para>
@@ -1252,7 +1252,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Determines the percentage of documentation</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Determines the percentage of documentation in a given script</maml:para>
@@ -1395,7 +1395,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's MAML</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Generates a Module's MAML file, and then saves it to the appropriate location.</maml:para>
@@ -1649,7 +1649,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.3</dev:version>
+      <dev:version>0.3.1</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Get markdown help for each command in a module and saves it to the appropriate location.</maml:para>
@@ -1770,6 +1770,32 @@ If an exact match is not found -ScriptPath will also check to see if there is a 
           <maml:name>ReplaceScriptNameWith</maml:name>
           <maml:description>
             <maml:para>If provided, will replace parts of the names of the scripts discovered in a -ScriptDirectory beneath a module with a given Regex replacement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>System.String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>
+          </dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" position="named" pipelineInput="True (ByPropertyName)" aliases="" variableLength="true" globbing="false">
+          <maml:name>ReplaceLink</maml:name>
+          <maml:description>
+            <maml:para>If provided, will replace links discovered in markdown content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>System.String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>
+          </dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" position="named" pipelineInput="True (ByPropertyName)" aliases="" variableLength="true" globbing="false">
+          <maml:name>ReplaceLinkWith</maml:name>
+          <maml:description>
+            <maml:para>If provided, will replace links discovered in markdown content with a given Regex replacement.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
           <dev:type>
@@ -2005,6 +2031,32 @@ If not provided, will be assumed to be the "docs" folder of a given module (unle
         <maml:name>ReplaceCommandNameWith</maml:name>
         <maml:description>
           <maml:para>If provided, will replace parts of the names of the scripts discovered in a -Command parameter with a given Regex replacement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>System.String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>
+        </dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+        <maml:name>ReplaceLink</maml:name>
+        <maml:description>
+          <maml:para>If provided, will replace links discovered in markdown content.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>System.String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>
+        </dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+        <maml:name>ReplaceLinkWith</maml:name>
+        <maml:description>
+          <maml:para>If provided, will replace links discovered in markdown content with a given Regex replacement.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
         <dev:type>

--- a/HelpOut.format.ps1xml
+++ b/HelpOut.format.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.8.8: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.9.0: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <ViewDefinitions>
     <View>

--- a/HelpOut.psd1
+++ b/HelpOut.psd1
@@ -6,7 +6,7 @@
     Author='James Brundage'
     ModuleToProcess='HelpOut.psm1'
     FormatsToProcess='HelpOut.format.ps1xml'
-    ModuleVersion='0.3'
+    ModuleVersion='0.3.1'
     PrivateData = @{
         PSData = @{
             ProjectURI = 'https://github.com/StartAutomating/HelpOut'
@@ -14,6 +14,12 @@
 
             Tags = 'Markdown', 'Help','PowerShell'
             ReleaseNotes = @'
+### 0.3.1
+* Save-MarkdownHelp:  
+  * Can now -ReplaceLink (Fixes #66)
+  * -ReplaceLink will always replace -OutputPath (Fixes #67)
+  * Changing Aliases for -SkipCommandType (Fixes #65)
+---
 ### 0.3:
 * Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
 * Workflow improvements:  Building formatting / types in CI/CD (#63)

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -99,7 +99,7 @@ function Save-MarkdownHelp
     # A list of command types to skip.  
     # If not provided, all types of commands from the module will be saved as a markdown document.
     [Parameter(ValueFromPipelineByPropertyName)]
-    [Alias('SkipCommandTypes','OmitCommandType','OmitCommandTypes')]
+    [Alias('SkipCommandTypes','ExcludeCommandType','ExcludeCommandTypes')]
     [Management.Automation.CommandTypes[]]
     $SkipCommandType
     )

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -158,6 +158,9 @@ function Save-MarkdownHelp
                 $null = New-Item -ItemType Directory -Path $OutputPath # create it.
             }
 
+            $outputPathName = $OutputPath | Split-Path -Leaf
+            $ReplaceLink   += "^$outputPathName[\\/]"
+
             # Double-check that the output path 
             $outputPathItem = Get-Item $OutputPath
             if ($outputPathItem -isnot [IO.DirectoryInfo]) { # is not a directory

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -63,6 +63,16 @@ function Save-MarkdownHelp
     [string[]]
     $ReplaceScriptNameWith = @(),
 
+    # If provided, will replace links discovered in markdown content.
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [string[]]
+    $ReplaceLink,
+
+    # If provided, will replace links discovered in markdown content with a given Regex replacement.
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [string[]]
+    $ReplaceLinkWith = @(),
+
     # If set, will output changed or created files.
     [switch]
     $PassThru,
@@ -112,6 +122,8 @@ function Save-MarkdownHelp
             } else {
                 $ExecutionContext.SessionState.InvokeCommand.GetCommand('Get-MarkdownHelp', 'Function')
             }
+
+        $filesChanged = @()
     }
 
     process {        
@@ -220,8 +232,12 @@ function Save-MarkdownHelp
                         Write-Error -Exception $ex.Exception -Message "Could not Get Help for $($cmd.Name): $($ex.Exception.Message)" -TargetObject $getMarkdownHelpSplat
                     }
 
-                    if ($PassThru) { # If -PassThru was provided
-                        Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue # return the created file.
+                    $filesChanged += # add the file to the changed list.
+                        Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue 
+
+                    # If -PassThru was provided (and we're not going to change anything)
+                    if ($PassThru -and -not $ReplaceLink) { 
+                        $filesChanged[-1] # output the file changed now.
                     }
 
                 }
@@ -277,8 +293,13 @@ function Save-MarkdownHelp
                             Out-String -Width 1mb | # format the result
                             Set-Content -Path $docOutputPath -Encoding utf8 # and save it to a file.
                         
-                        if ($PassThru) { # If -PassThru was provided
-                            Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue # return the created file.
+                        
+                        $filesChanged += # add the file to the changed list.
+                            Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue 
+    
+                        # If -PassThru was provided (and we're not going to change anything)
+                        if ($PassThru -and -not $ReplaceLink) { 
+                            $filesChanged[-1] # output the file changed now.
                         }
                     }                
             }
@@ -336,8 +357,14 @@ function Save-MarkdownHelp
                                 # Determine the output path
                                 $dest = Join-Path $OutputPath ($replacedName + '.md')
                                 # and make sure we're not overwriting ourselves
-                                if ($fileInfo.FullName -ne "$dest") { 
-                                    $fileInfo | Copy-Item -Destination $dest -PassThru:$PassThru # then copy the file.
+                                if ($fileInfo.FullName -ne "$dest") {                                     
+                                    $filesChanged += # copy the file and add it to the change list.
+                                        $fileInfo | Copy-Item -Destination $dest -PassThru 
+                                }
+
+                                # If -PassThru was passed and we're not changing anything.
+                                if ($PassThru -and -not $ReplaceLink) {
+                                    $filesChanged[-1] # output the file now.
                                 }
                             }
                         }
@@ -366,16 +393,60 @@ function Save-MarkdownHelp
                                         break
                                     }
                                     # Copy the file to the destination.
-                                    $fileInfo | Copy-Item -Destination $dest -PassThru:$PassThru
+                                    if ($fileInfo.FullName -ne "$dest") {                                     
+                                        $filesChanged += # and add it to the change list.
+                                            fileInfo | Copy-Item -Destination $dest -PassThru:$PassThru
+                                    }
+    
+                                    # If -PassThru was passed and we're not changing anything.
+                                    if ($PassThru -and -not $ReplaceLink) {
+                                        $filesChanged[-1] # output the file now.
+                                    }                                    
                                 }
                                 break
                             }
                         }
                     }
             }
+        }
 
-            
-         }
+        if ($PassThru -and $ReplaceLink) {
+            $linkFinder = [Regex]::new("            
+            (?<IsImage>\!)?    # If there is an exclamation point, then it is an image link
+            \[                 # Markdown links start with a bracket
+            (?<Text>[^\]\r\n]+)
+            \]                 # anything until the end bracket is the link text.
+            \(                 # The link uri is within parenthesis
+            (?<Uri>[^\)\r\n]+)
+            \)
+            ", 'IgnoreCase,IgnorePatternWhitespace')
+            foreach ($file in $filesChanged) {                
+                $fileContent = Get-Content $file.FullName -Raw
+                $fileContent = $linkFinder.Replace($fileContent, {
+                    param($LinkMatch)                    
+                    $linkReplacementNumber = 0
+
+                    $linkUri  = $LinkMatch.Groups["Uri"].ToString()
+                    $linkText = $linkMatch.Groups["Text"].ToString()
+                    foreach ($linkToReplace in $ReplaceLink) {
+                        $replacement = "$($ReplaceLinkWith[$linkReplacementNumber])"
+                        $linkUri  = $linkUri  -replace $linkToReplace, $replacement
+                        $linkText = $linkText -replace $linkToReplace, $replacement                        
+                    }
+
+                    if ($LinkMatch.Groups["IsImage"].Length) {
+                        "![$linkText]($linkUri)"
+                    } else {
+                        "[$linkText]($linkUri)"
+                    }                    
+                })
+                Set-Content $file.FullName -Encoding UTF8 -Value $fileContent
+                
+                if ($PassThru) {
+                    Get-Item -LiteralPath $file.FullName
+                }
+            }
+        }
 
         if ($t -gt 1) {
             Write-Progress 'Saving Markdown' 'Complete' -Completed -Id $id

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.3.1
+* Save-MarkdownHelp:  
+  * Can now -ReplaceLink (Fixes #66)
+  * -ReplaceLink will always replace -OutputPath (Fixes #67)
+  * Changing Aliases for -SkipCommandType (Fixes #65)
+---
+
 ### 0.3:
 * Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
 * Workflow improvements:  Building formatting / types in CI/CD (#63)

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,3 +29,4 @@ Get-Module HelpOut | Save-MarkdownHelp -Wiki  # Will generate a ../HelpOut.wiki 
 
 You can use HelpOut as a GitHub Action.  Doing so will run whatever .HelpOut.ps1 files exist in your repository.  If a -CommitMessage is provided, or attached to any files returned by the .HelpOut.ps1, the changes will be commited.
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-﻿# HelpOut
+# HelpOut
 ## A Helpful Toolkit for Managing PowerShell Help
 
 HelpOut is a Helpful Toolkit for Managing PowerShell Help.
@@ -28,3 +28,4 @@ Get-Module HelpOut | Save-MarkdownHelp -Wiki  # Will generate a ../HelpOut.wiki 
 ### Using HelpOut as a GitHub Action.
 
 You can use HelpOut as a GitHub Action.  Doing so will run whatever .HelpOut.ps1 files exist in your repository.  If a -CommitMessage is provided, or attached to any files returned by the .HelpOut.ps1, the changes will be commited.
+

--- a/docs/Save-MarkdownHelp.md
+++ b/docs/Save-MarkdownHelp.md
@@ -121,6 +121,26 @@ If provided, will replace parts of the names of the scripts discovered in a -Scr
 |----------------|--------|-------|---------------------|
 |```[String[]]```|false   |named  |true (ByPropertyName)|
 ---
+#### **ReplaceLink**
+
+If provided, will replace links discovered in markdown content.
+
+
+
+|Type            |Requried|Postion|PipelineInput        |
+|----------------|--------|-------|---------------------|
+|```[String[]]```|false   |named  |true (ByPropertyName)|
+---
+#### **ReplaceLinkWith**
+
+If provided, will replace links discovered in markdown content with a given Regex replacement.
+
+
+
+|Type            |Requried|Postion|PipelineInput        |
+|----------------|--------|-------|---------------------|
+|```[String[]]```|false   |named  |true (ByPropertyName)|
+---
 #### **PassThru**
 
 If set, will output changed or created files.
@@ -212,7 +232,7 @@ Valid Values:
 ---
 ### Syntax
 ```PowerShell
-Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-IncludeExtension <String[]>] [-NoValidValueEnumeration] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [<CommonParameters>]
+Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-ReplaceLink <String[]>] [-ReplaceLinkWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-IncludeExtension <String[]>] [-NoValidValueEnumeration] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [<CommonParameters>]
 ```
 ---
 


### PR DESCRIPTION
### 0.3.1
* Save-MarkdownHelp:  
  * Can now -ReplaceLink (Fixes #66)
  * -ReplaceLink will always replace -OutputPath (Fixes #67)
  * Changing Aliases for -SkipCommandType (Fixes #65)
---