### PR TITLE
HelpOut 0.4.5

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [StartAutomating]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-### 0.4.4
+### HelpOut 0.4.5:
+
+* You can now sponsor HelpOut (#126)
+* Added ScriptMethods to PowerShell.Markdown.Help (#125)
+* Now allowing Save-MarkDownHelp to be extended by any HelpOut.SaveMarkdownHelp file or function (#123)
+* Auto-documenting extended types (#101)
+
+---
+
+### HelpOut 0.4.4:
 
 * Improved HelpOut action output (Fixes #121)
 * HelpOut has a logo (Fixes #120)
@@ -6,7 +15,7 @@
 
 ---
 
-### 0.4.3
+### HelpOut 0.4.3:
 
 * Action Improvements:
   * Not obeying -InstallModule if a local module is found (Fixes #113)
@@ -15,7 +24,7 @@
 
 ---
 
-### 0.4.2
+### HelpOut 0.4.2:
 
 * Markdown Help Improvements:
   * Adding Aliases (Fixes #111)
@@ -34,15 +43,14 @@
 
 ---
 
-
-### 0.4.1
+### HelpOut 0.4.1:
 
 * Parameter Properties are now rendered as a table (Fixes #98)
 * Save-MarkdownHelp:  Adding -ExcludeFile (Fixes #97)
 
 ---
 
-### 0.4
+### HelpOut 0.4:
 
 * Get/Save-MarkdownHelp:
   * Adding -YamlHeaderInformationType and including [Reflection.AssemblyMetaData] attributes (Fixes #93)
@@ -51,52 +59,52 @@
 
 ---
 
-### 0.3.9
+### HelpOut 0.3.9:
 
 * No longer attempting to repair links if the file is not markdown (Fixes #88)
 
 ---
 
-### 0.3.8
+### HelpOut 0.3.8:
 
 * YAML Header is now optional (with -IncludeYamlHeader) (Fixes #80)
 * Save-MarkdownHelp trims content (Fixes #85)
 
 ---
 
-### 0.3.7
+### HelpOut 0.3.7:
 
 All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fixes #80)
 
 ---
 
-### 0.3.6
+### HelpOut 0.3.6:
 * Improvements to [OutputType] support (Fixes #78)
 * GitHub Action No Longer Runs when not on a branch (Fixes #77)
 
 ---
 
-### 0.3.5
+### HelpOut 0.3.5:
 * Markdown Help Improvements: Escaping Example Code (Fixes #75)
 
 ---
 
-### 0.3.4
+### HelpOut 0.3.4:
 * Fixing accidental heading names in .Link and parameter properties (Fixes #73)
 
 ---
 
-### 0.3.3
+### HelpOut 0.3.3:
 * Markdown Help now uses fewer tables (improves default GitHub Page rendering) (fixes #71)
 
 ---
 
-### 0.3.2
+### HelpOut 0.3.2:
 * Save-MarkdownHelp Bugfix (Fixes #69)
 
 ---
 
-### 0.3.1
+### HelpOut 0.3.1:
 * Save-MarkdownHelp:  
   * Can now -ReplaceLink (Fixes #66)
   * -ReplaceLink will always replace -OutputPath (Fixes #67)
@@ -104,11 +112,14 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.3:
+
+### HelpOut 0.3:
 * Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
 * Workflow improvements:  Building formatting / types in CI/CD (#63)
+
 ---
-### 0.2.9:
+
+### HelpOut 0.2.9:
 * Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
 * Action improvements:
   * Pulling just before push (#59)
@@ -116,7 +127,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.8:
+### HelpOut 0.2.8:
 * Save-MarkdownHelp:
   * Adding -ExcludeTopic (#55)
   * -IncludeTopic excludes deeply nested topics (#54)
@@ -124,7 +135,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.7
+### HelpOut 0.2.7:
 * Save-MarkdownHelp:
   * Adding -Command, -ReplaceCommandName, -ReplaceCommandNameWith (#45)
   * Fixing -ReplaceScriptName issue (#46)
@@ -134,7 +145,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.6
+### HelpOut 0.2.6:
 * Save-MarkdownHelp:
   * Improving Inline Documentation
   * Allowing -ScriptPath to be a Regex (#41)
@@ -143,7 +154,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.5
+### HelpOut 0.2.5:
 * Save-MarkdownHelp:
   * Adding -IncludeExtension (#35)
   * Applying -PassThru to -IncludeTopic (#34)
@@ -152,7 +163,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.4
+### HelpOut 0.2.4:
 * Save-MarkdownHelp:
   * Adding -SkipCommandType (#29)
   * -ScriptPath now allows wildcards (#28)
@@ -160,7 +171,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.3
+### HelpOut 0.2.3:
 * Get/Save-MarkdownHelp:  Support for -NoValidValueEnumeration (re #25)
 * Save-MarkdownHelp:  Adding -IncludeTopic (Fixes #24, #26)
 * Adding ValidateSet/Enum Formatting for Markdown Help (Fixing #25)
@@ -168,13 +179,13 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.2
+### HelpOut 0.2.2:
 * Fixing issue generating docs (#22)
 * HelpOut Action Fix (#20)
 
 ---
 
-### 0.2.1
+### HelpOut 0.2.1:
 * Get/Save-MarkdownHelp:  Support for -SectionOrder (#19)
 * Save-MarkdownHelp:  Adding -Passthru (#17).  Converting Markdown Help into a string (#18)
 * Get-MarkdownHelp: Returning Object (#18)
@@ -184,7 +195,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2
+### HelpOut 0.2:
 * Adding Install-MAML (#1/ #7)
 * Adding Get-MarkdownHelp (#4)
 * Adding Save-MarkdownHelp (#10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * You can now sponsor HelpOut (#126)
 * Added ScriptMethods to PowerShell.Markdown.Help (#125)
 * Now allowing Save-MarkDownHelp to be extended by any HelpOut.SaveMarkdownHelp file or function (#123)
-* Auto-documenting extended types (#101)
+* This is used in HelpOut.SaveMarkdownHelp.ExtendedTypes, which auto documents extended types (#101)
 
 ---
 

--- a/Formatting/PowerShell.Markdown.Help.format.ps1
+++ b/Formatting/PowerShell.Markdown.Help.format.ps1
@@ -322,9 +322,11 @@ If the command sets a ```[ConfirmImpact("Medium")]``` which is lower than ```$co
 
         $sectionCounter = 0
         foreach ($sectionName in $orderOfSections) {
+
             $sectionCounter++
             $sectionContent =
-                if ($MarkdownSections.$sectionName -is [ScriptBlock]) {
+                if ($MarkdownSections.$sectionName -is [ScriptBlock] -and 
+                    $helpObject.HideSections -notcontains $sectionName) {
                     & $MarkdownSections.$sectionName
                 } else { $null }
             if ($sectionContent) {

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -8,7 +8,7 @@
       <maml:description>
         <maml:para>Gets MAML help</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets help for a given command, as MAML (Microsoft Assistance Markup Language) xml.</maml:para>
@@ -400,7 +400,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Gets Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets Help for a given command, in Markdown</maml:para>
@@ -666,7 +666,7 @@ If not provided, this will be the order they are defined in the formatter.</maml
       <maml:description>
         <maml:para>Gets a script's references</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the external references of a given PowerShell command.  These are the commands the script calls, and the types the script uses.</maml:para>
@@ -792,7 +792,7 @@ If not provided, this will be the order they are defined in the formatter.</maml
       <maml:description>
         <maml:para>Gets a Script's story</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the Script's "Story"</maml:para>
@@ -955,7 +955,7 @@ If not provided, this will be the order they are defined in the formatter.</maml
       <maml:description>
         <maml:para>Installs MAML into a module</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Installs MAML into a module.  </maml:para>
@@ -1309,7 +1309,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Determines the percentage of documentation</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Determines the percentage of documentation in a given script</maml:para>
@@ -1452,7 +1452,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's MAML</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Generates a Module's MAML file, and then saves it to the appropriate location.</maml:para>
@@ -1713,7 +1713,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.4.4</dev:version>
+      <dev:version>0.4.5</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Get markdown help for each command in a module and saves it to the appropriate location.</maml:para>

--- a/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
+++ b/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
@@ -55,17 +55,10 @@ foreach ($extendedType in $extendedTypeNames) {
                 }
             $temporaryFunctionName = "$($extendedType).$GetSetNothing$($member.Name)" -replace $replaceMostPunctuation        
             $ExecutionContext.SessionState.PSVariable.Set("function:$($temporaryFunctionName)", $member.$PotentialProperty)
-            # Then Get-MarkdownHelp
-            $markdownHelp = Get-MarkdownHelp -Name $temporaryFunctionName @getMarkdownHelpSplatBase |
-                Out-String -Width 1mb # and format the result
-            # Then determine the exported file name
-            $exportedFileName = "$($temporaryFunctionName).md"
-            # and absolute path.
-            $exportedFilePath = Join-Path $outputPath $exportedFileName
-            # Then write the content,
-            Set-Content -Path $exportedFilePath -Value $markdownHelp
-            # return the file
-            Get-Item -Path $exportedFilePath
+            # Then Get-MarkdownHelp,
+            $markdownHelp = Get-MarkdownHelp -Name $temporaryFunctionName @getMarkdownHelpSplatBase
+            # .Save it,
+            $markdownHelp.Save((Join-Path $outputPath "$($temporaryFunctionName).md"))            
             # and remove the temporary function (it would have gone out of scope anyways)
             $ExecutionContext.SessionState.PSVariable.Remove("function:$($temporaryFunctionName)")
         }

--- a/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
+++ b/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
@@ -41,7 +41,7 @@ foreach ($extendedType in $extendedTypeNames) {
 
         foreach ($potentialProperty in 'Script','GetScriptBlock','SetScriptBlock') {
             if ($member.$PotentialProperty -notlike '*<#*.synopsis*#>*') { continue }
-
+            $markdownSplat = @{}
             # Create a temporary function to hold the help.
             $getSetNothing = 
                 if ($potentialProperty -eq 'GetScriptBlock') {
@@ -51,12 +51,14 @@ foreach ($extendedType in $extendedTypeNames) {
                     "set_"
                 }
                 elseif ($potentialProperty -eq 'Script') {
-                    ''
+                    ''                    
                 }
-            $temporaryFunctionName = "$($extendedType).$GetSetNothing$($member.Name)" -replace $replaceMostPunctuation        
+            $temporaryFunctionName = "$($extendedType).$GetSetNothing$($member.Name)" -replace $replaceMostPunctuation
+            $markdownSplat.Rename = "$temporaryFunctionName()"        
             $ExecutionContext.SessionState.PSVariable.Set("function:$($temporaryFunctionName)", $member.$PotentialProperty)
             # Then Get-MarkdownHelp,
-            $markdownHelp = Get-MarkdownHelp -Name $temporaryFunctionName @getMarkdownHelpSplatBase
+            $markdownHelp = Get-MarkdownHelp -Name $temporaryFunctionName @getMarkdownHelpSplatBase @markdownSplat
+            $markdownHelp.HideSection("Syntax")
             # .Save it,
             $markdownHelp.Save((Join-Path $outputPath "$($temporaryFunctionName).md"))            
             # and remove the temporary function (it would have gone out of scope anyways)

--- a/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
+++ b/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Saves Markdown Help for Extended Types
+.DESCRIPTION
+    This saves Markdown Help from Extended Types (types.ps1xml) files.
+#>
+param(
+# The module that contains extended types
+$Module
+)
+
+# If there is no module, return
+if (-not $module) { return }
+
+# If the module is a string, get the actual module
+if ($module -is [string]) {
+    $module = Get-Module -Name $module
+}
+
+# If there were not exported type files, return
+if (-not $module.ExportedTypeFiles) {
+    return
+}
+
+# Get each extended type name
+$extendedTypeNames = 
+    @($module.ExportedTypeFiles) |
+    Select-Xml //Type -Path { $_ } |
+    Select-Object -ExpandProperty Node |
+    Select-Object -ExpandProperty Name
+
+# and be ready to replace most punctuation
+$replaceMostPunctuation = '[\p{P}-[\-\._]]'
+# go over each extended type
+foreach ($extendedType in $extendedTypeNames) {
+    # and get the actual type data
+    $actualTypeData = Get-TypeData -TypeName $extendedType
+    foreach ($member in $actualTypeData.Members.Values) {
+        # If the script looks like it does not have inline help, continue
+        
+
+        foreach ($potentialProperty in 'Script','GetScriptBlock','SetScriptBlock') {
+            if ($member.$PotentialProperty -notlike '*<#*.synopsis*#>*') { continue }
+
+            # Create a temporary function to hold the help.
+            $getSetNothing = 
+                if ($potentialProperty -eq 'GetScriptBlock') {
+                    "get_"
+                }
+                elseif ($potentialProperty -eq 'SetScriptBlock') {
+                    "set_"
+                }
+                elseif ($potentialProperty -eq 'Script') {
+                    ''
+                }
+            $temporaryFunctionName = "$($extendedType).$GetSetNothing$($member.Name)" -replace $replaceMostPunctuation        
+            $ExecutionContext.SessionState.PSVariable.Set("function:$($temporaryFunctionName)", $member.$PotentialProperty)
+            # Then Get-MarkdownHelp
+            $markdownHelp = Get-MarkdownHelp -Name $temporaryFunctionName @getMarkdownHelpSplatBase |
+                Out-String -Width 1mb # and format the result
+            # Then determine the exported file name
+            $exportedFileName = "$($temporaryFunctionName).md"
+            # and absolute path.
+            $exportedFilePath = Join-Path $outputPath $exportedFileName
+            # Then write the content,
+            Set-Content -Path $exportedFilePath -Value $markdownHelp
+            # return the file
+            Get-Item -Path $exportedFilePath
+            # and remove the temporary function (it would have gone out of scope anyways)
+            $ExecutionContext.SessionState.PSVariable.Remove("function:$($temporaryFunctionName)")
+        }
+
+        
+    }
+}

--- a/HelpOut.format.ps1xml
+++ b/HelpOut.format.ps1xml
@@ -435,9 +435,11 @@ If the command sets a ```[ConfirmImpact("Medium")]``` which is lower than ```$co
 
         $sectionCounter = 0
         foreach ($sectionName in $orderOfSections) {
+
             $sectionCounter++
             $sectionContent =
-                if ($MarkdownSections.$sectionName -is [ScriptBlock]) {
+                if ($MarkdownSections.$sectionName -is [ScriptBlock] -and 
+                    $helpObject.HideSections -notcontains $sectionName) {
                     &amp; $MarkdownSections.$sectionName
                 } else { $null }
             if ($sectionContent) {

--- a/HelpOut.psd1
+++ b/HelpOut.psd1
@@ -7,7 +7,7 @@
     ModuleToProcess='HelpOut.psm1'
     FormatsToProcess='HelpOut.format.ps1xml'
     TypesToProcess='HelpOut.types.ps1xml'
-    ModuleVersion='0.4.4'
+    ModuleVersion='0.4.5'
     PrivateData = @{
         PSData = @{
             ProjectURI = 'https://github.com/StartAutomating/HelpOut'
@@ -15,202 +15,16 @@
 
             Tags = 'Markdown', 'Help','PowerShell'
             ReleaseNotes = @'
-### 0.4.4
+### HelpOut 0.4.5:
 
-* Improved HelpOut action output (Fixes #121)
-* HelpOut has a logo (Fixes #120)
-* Save-MarkdownHelp now trims content (Fixes #119)
-
----
-
-### 0.4.3
-
-* Action Improvements:
-  * Not obeying -InstallModule if a local module is found (Fixes #113)
-  * Not adding files found outside of the workspace (Fixes #114)
-  * Checking for detached branch before pulling (Fixes #103)
+* You can now sponsor HelpOut (#126)
+* Added ScriptMethods to PowerShell.Markdown.Help (#125)
+* Now allowing Save-MarkDownHelp to be extended by any HelpOut.SaveMarkdownHelp file or function (#123)
+* Auto-documenting extended types (#101)
 
 ---
 
-### 0.4.2
-
-* Markdown Help Improvements:
-  * Adding Aliases (Fixes #111)
-  * Removing Horizontal Rule between parameters (Fixes #110)
-  * Adding newline before and after each section
-  * Supporting Script Stories (Fixes #104)
-  * [Ordered] Synopsis and Description (Fixes #107)
-  * Sorting front matter by Position (descending) and Name (Fixes #107)
-  * Moving Syntax below Notes and Story (re #104)
-* Get-ScriptStory:
-  * Defaulting -HeadingSize to 3
-* Action Improvements:
-  * Better Terminal Output / Removing Output Variables (Fixes #109)
-  * Improving branchless error behavior (Fixes #103)
-  * Adding -InstallModule (Fixes #108)
-
----
-
-### 0.4.1
-
-* Parameter Properties are now rendered as a table (Fixes #98)
-* Save-MarkdownHelp:  Adding -ExcludeFile (Fixes #97)
-
----
-
-### 0.4
-
-* Get/Save-MarkdownHelp:
-  * Adding -YamlHeaderInformationType and including [Reflection.AssemblyMetaData] attributes (Fixes #93)
-* Replacing anchor links with lowercase (Fixes #92)
-* Returning unmodified files when no link is replaced (Fixes #91)
-
----
-
-### 0.3.9
-
-* No longer attempting to repair links if the file is not markdown (Fixes #88)
-
----
-
-### 0.3.8
-
-* YAML Header is now optional (with -IncludeYamlHeader) (Fixes #80)
-* Save-MarkdownHelp trims content (Fixes #85)
-
----
-
-### 0.3.7
-
-All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fixes #80)
-
----
-
-### 0.3.6
-* Improvements to [OutputType] support (Fixes #78)
-* GitHub Action No Longer Runs when not on a branch (Fixes #77)
-
----
-
-### 0.3.5
-* Markdown Help Improvements: Escaping Example Code (Fixes #75)
-
----
-
-### 0.3.4
-* Fixing accidental heading names in .Link and parameter properties (Fixes #73)
-
----
-
-### 0.3.3
-* Markdown Help now uses fewer tables (improves default GitHub Page rendering) (fixes #71)
-
----
-
-### 0.3.2
-* Save-MarkdownHelp Bugfix (Fixes #69)
-
----
-
-### 0.3.1
-* Save-MarkdownHelp:  
-  * Can now -ReplaceLink (Fixes #66)
-  * -ReplaceLink will always replace -OutputPath (Fixes #67)
-  * Changing Aliases for -SkipCommandType (Fixes #65)
-
----
-
-### 0.3:
-* Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
-* Workflow improvements:  Building formatting / types in CI/CD (#63)
----
-### 0.2.9:
-* Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
-* Action improvements:
-  * Pulling just before push (#59)
-  * Improving username / email detection (#60)
-
----
-
-### 0.2.8:
-* Save-MarkdownHelp:
-  * Adding -ExcludeTopic (#55)
-  * -IncludeTopic excludes deeply nested topics (#54)
-  * -IncludeExtension default now includes .svg files (#53)
-
----
-
-### 0.2.7
-* Save-MarkdownHelp:
-  * Adding -Command, -ReplaceCommandName, -ReplaceCommandNameWith (#45)
-  * Fixing -ReplaceScriptName issue (#46)
-* Save-MAML:
-  * -PassThru now returns files, not file contents (#47)
-* HelpOut.HelpOut.ps1 Added (Selfhosting Action (#48))
-
----
-
-### 0.2.6
-* Save-MarkdownHelp:
-  * Improving Inline Documentation
-  * Allowing -ScriptPath to be a Regex (#41)
-  * Fixing Relative Paths with -IncludeExtension (#42)
-  * Improving -IncludeTopic regex behavior (#43)
-
----
-
-### 0.2.5
-* Save-MarkdownHelp:
-  * Adding -IncludeExtension (#35)
-  * Applying -PassThru to -IncludeTopic (#34)
-  * Allowing wildcards in -IncludeTopic (#33)
-* Preliminary support for GitHub Pages Publishing (#32)
-
----
-
-### 0.2.4
-* Save-MarkdownHelp:
-  * Adding -SkipCommandType (#29)
-  * -ScriptPath now allows wildcards (#28)
-* Formatting now Handles Arrays of Enums (#30)
-
----
-
-### 0.2.3
-* Get/Save-MarkdownHelp:  Support for -NoValidValueEnumeration (re #25)
-* Save-MarkdownHelp:  Adding -IncludeTopic (Fixes #24, #26)
-* Adding ValidateSet/Enum Formatting for Markdown Help (Fixing #25)
-
-
----
-
-### 0.2.2
-* Fixing issue generating docs (#22)
-* HelpOut Action Fix (#20)
-
----
-
-### 0.2.1
-* Get/Save-MarkdownHelp:  Support for -SectionOrder (#19)
-* Save-MarkdownHelp:  Adding -Passthru (#17).  Converting Markdown Help into a string (#18)
-* Get-MarkdownHelp: Returning Object (#18)
-* Fixing URL-only related links (#14)
-* Adding Get-MarkdownHelp -Rename (#13)
-* Retitling Script Files with relative path (#12)
-
----
-
-### 0.2
-* Adding Install-MAML (#1/ #7)
-* Adding Get-MarkdownHelp (#4)
-* Adding Save-MarkdownHelp (#10)
-* Adding HelpOut Action (#5)
-* Adding Measure-Help (#11)
-* Adding Get-ScriptStory (#3)
-* Adding Get-ScriptReference (#2)
-* Renmaing ConvertTo-MAML->Get-MAML
-
----
+Additional Changes in [ChangeLog](/CHANGELOG.md)
 '@
         }
     }

--- a/HelpOut.psd1
+++ b/HelpOut.psd1
@@ -6,6 +6,7 @@
     Author='James Brundage'
     ModuleToProcess='HelpOut.psm1'
     FormatsToProcess='HelpOut.format.ps1xml'
+    TypesToProcess='HelpOut.types.ps1xml'
     ModuleVersion='0.4.4'
     PrivateData = @{
         PSData = @{

--- a/HelpOut.psd1
+++ b/HelpOut.psd1
@@ -20,7 +20,7 @@
 * You can now sponsor HelpOut (#126)
 * Added ScriptMethods to PowerShell.Markdown.Help (#125)
 * Now allowing Save-MarkDownHelp to be extended by any HelpOut.SaveMarkdownHelp file or function (#123)
-* Auto-documenting extended types (#101)
+* This is used in HelpOut.SaveMarkdownHelp.ExtendedTypes, which auto documents extended types (#101)
 
 ---
 

--- a/HelpOut.types.ps1xml
+++ b/HelpOut.types.ps1xml
@@ -34,6 +34,37 @@ $this |
 
                     </Script>
       </ScriptMethod>
+      <ScriptMethod>
+        <Name>ShowSection</Name>
+        <Script>
+                        &lt;#
+.SYNOPSIS
+    Shows sections of markdown help
+.DESCRIPTION
+    Shows sections of a command's markdown help.
+#&gt;
+param(
+# One or more section names
+[ValidateSet('Name','Synopsis','Description','RelatedLinks','Examples','Parameters','Inputs','Outputs','Notes','Story','Syntax')]
+[Alias('SectionName')]
+[string[]]
+$SectionNames
+)
+
+$skipSectionNames = @($This.HideSections)
+foreach ($SectionName in $SectionNames) {
+    if ($skipSectionNames -contains $SectionName) {     
+        $skipSectionNames = @($skipSectionNames -ne $SectionName)
+    }
+}
+
+$this | 
+    Add-Member NoteProperty HideSections $skipSectionNames -Force
+
+
+
+                    </Script>
+      </ScriptMethod>
     </Members>
   </Type>
 </Types>

--- a/HelpOut.types.ps1xml
+++ b/HelpOut.types.ps1xml
@@ -35,6 +35,43 @@ $this |
                     </Script>
       </ScriptMethod>
       <ScriptMethod>
+        <Name>Save</Name>
+        <Script>
+                        &lt;#
+.SYNOPSIS
+    Saves a Markdown Help Topic
+.DESCRIPTION
+    Saves a Markdown Help Topic to a file.
+.EXAMPLE
+    (Get-MarkdownHelp Get-MarkdownHelp).Save(".\test.md")
+.LINK
+    PowerShell.Markdown.Help.ToMarkdown
+#&gt;
+param(
+# The path to the file.
+# If this does not exist it will be created.
+[string]
+$FilePath,
+
+# An optional view.
+# This would need to be declared in a .format.ps1xml file by another loaded module.
+[string]
+$View = 'PowerShell.Markdown.Help'
+)
+
+if (-not (Test-Path $FilePath)) {
+    $createdFile = New-Item -ItemType File -Path $FilePath -Force
+    if (-not $createdFile) { return }
+}
+
+Set-Content -Path $filePath -Value $this.ToMarkdown($view)
+
+if ($?) {
+    Get-Item -Path $FilePath
+}
+                    </Script>
+      </ScriptMethod>
+      <ScriptMethod>
         <Name>ShowSection</Name>
         <Script>
                         &lt;#
@@ -63,6 +100,29 @@ $this |
 
 
 
+                    </Script>
+      </ScriptMethod>
+      <ScriptMethod>
+        <Name>ToMarkdown</Name>
+        <Script>
+                        &lt;#
+.SYNOPSIS
+    Returns this topic as a markdown string
+.DESCRIPTION
+    Returns the content of this help topic as a markdown string.
+.EXAMPLE
+
+#&gt;
+param(
+# An optional view.
+# This would need to be declared in a .format.ps1xml file by another loaded module.
+[string]
+$View = 'PowerShell.Markdown.Help'
+)
+
+($this |
+    Format-Custom -View $View |
+    Out-String -Width 1mb).Trim()
                     </Script>
       </ScriptMethod>
     </Members>

--- a/HelpOut.types.ps1xml
+++ b/HelpOut.types.ps1xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-16"?>
+<!-- Generated with EZOut 1.9.9: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<Types>
+  <Type>
+    <Name>PowerShell.Markdown.Help</Name>
+    <Members>
+      <ScriptMethod>
+        <Name>HideSection</Name>
+        <Script>
+                        &lt;#
+.SYNOPSIS
+    Hides sections of markdown help
+.DESCRIPTION
+    Hides sections of a command's markdown help.
+#&gt;
+param(
+# One or more section names.
+[ValidateSet('Name','Synopsis','Description','RelatedLinks','Examples','Parameters','Inputs','Outputs','Notes','Story','Syntax')]
+[Alias('SectionName')]
+[string[]]
+$SectionNames
+)
+
+
+$skipSectionNames = @($This.HideSections)
+foreach ($SectionName in $SectionNames) {
+    if ($skipSectionNames -notcontains $SectionName) {     
+        $skipSectionNames += $SectionName 
+    }
+}
+
+$this | 
+    Add-Member NoteProperty HideSections $skipSectionNames -Force
+
+                    </Script>
+      </ScriptMethod>
+    </Members>
+  </Type>
+</Types>

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -225,13 +225,11 @@
                 # otherwise, pass down the parent of $OutputPath.
                 else { $getMarkdownHelpSplat.GitHubDocRoot = "$($outputPath|Split-Path -Leaf)"}
 
-                & $GetMarkdownHelp @getMarkdownHelpSplat | # Call Get-MarkdownHelp
-                    Out-String -Width 1mb                | # output it as a string
-                    ForEach-Object { $_.Trim()}          | # trim it
-                    Set-Content -Path $docOutputPath -Encoding utf8  # and set the encoding.
+                
+                $markdownFile = (Get-MarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath)
 
                 if ($PassThru) { # If -PassThru was provided, get the path.
-                    Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue
+                    $markdownFile
                 }
             }
 
@@ -266,10 +264,7 @@
                     else { $getMarkdownHelpSplat.GitHubDocRoot = "$($outputPath|Split-Path -Leaf)"}
 
                     try {
-                        & $GetMarkdownHelp @getMarkdownHelpSplat | # Call Get-MarkdownHelp
-                            Out-String -Width 1mb                | # output it as a string
-                            ForEach-Object { $_.Trim()}          | # trim it
-                            Set-Content -Path $docOutputPath -Encoding utf8  # and set the encoding.
+                        $markdownFile = (Get-MarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath)                        
                     }
                     catch {
                         $ex = $_
@@ -277,7 +272,7 @@
                     }
 
                     $filesChanged += # add the file to the changed list.
-                        Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue
+                        $markdownFile
 
                     # If -PassThru was provided (and we're not going to change anything)
                     if ($PassThru -and -not $ReplaceLink) {
@@ -333,22 +328,14 @@
                         $getMarkdownHelpSplat.Rename = $relativePath
                         if ($Wiki) { $getMarkdownHelpSplat.Wiki = $Wiki}
                         else { $getMarkdownHelpSplat.GitHubDocRoot = "$($outputPath|Split-Path -Leaf)"}
-                        # Call Get-MarkdownHelp
-                        $markdownHelp = & $GetMarkdownHelp @getMarkdownHelpSplat |
-                            Out-String -Width 1mb # format the result
-
-                        if ($markdownHelp) {
-                            $markdownHelp.Trim() |
-                                Set-Content -Path $docOutputPath -Encoding utf8 # and save it to a file.
-                        }
-
-
-                        $filesChanged += # add the file to the changed list.
-                            Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue
-
+                        # Call Get-MarkdownHelp, .Save it, and
+                        $markdownFile = (& $GetMarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath) |
+                            
+                        $filesChanged += $markdownFile # add the file to the changed list.
+                                                    
                         # If -PassThru was provided (and we're not going to change anything)
                         if ($PassThru -and -not $ReplaceLink) {
-                            $filesChanged[-1] # output the file changed now.
+                            $markdownFile # output the file changed now.
                         }
                     }
             }

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -459,6 +459,64 @@
                         }
                     }
             }
+
+            #region Run Extensions to this Command
+            $MyModule = $MyInvocation.MyCommand.ScriptBlock.Module
+            $ScriptPattern   = "$($MyModule.Name)\.$($MyInvocation.MyCommand.Name -replace '\p{P}')\.(?<Name>(?:.|\s){0,}?(?=\z|\.ps1))\.ps1"
+            $commandWildcard = "$($MyModule.Name).$($MyInvocation.MyCommand.Name)*" 
+            $commandPattern  = "$($myModule.Name)\.$($MyInvocation.MyCommand.Name -replace '\p{P}')\.(?<Name>(?:.|\s){0,}?(?=\z|\.ps1))"
+            $myExtensions = @(
+                foreach ($loadedModule in Get-Module){
+                    if ($loadedModule -eq $MyModule -or 
+                        $loadedModule -eq $m -or 
+                        $loadedModule.Tags -contains $MyModule.Name) {
+                        foreach ($file in Get-ChildItem -Recurse -Filter *.ps1 (
+                            Split-Path $loadedModule.Path
+                        )) {
+
+                            if ($file.Name -notmatch $ScriptPattern) {
+                                continue
+                            }
+                            $scriptCmd = $ExecutionContext.SessionState.InvokeCommand.GetCommand($file.FullName, 'ExternalScript')
+                            $scriptCmd.psobject.Members.Add([psnoteproperty]::new("ExtensionName", $Matches.Name), $true)
+                            if ($scriptCmd.pstypenames -notcontains "$($myModule.Name).Extension") {                        
+                                $scriptCmd.pstypenames.insert(0, "$($myModule.Name).Extension")
+                            }
+                            $scriptCmd
+                        }
+                    }                
+                }
+                foreach ($cmdFound in $ExecutionContext.SessionState.InvokeCommand.GetCommands(
+                    $commandWildcard, 'Function,Alias,Cmdlet', $true
+                ) -match $commandPattern) {
+                    $cmdFound.psobject.Members.Add([psnoteproperty]::new("ExtensionName", $Matches.Name), $true)
+                    if ($cmdFound.pstypenames -notcontains "$($myModule.Name).Extension") {
+                        $cmdFound.pstypenames.insert(0, "$($myModule.Name).Extension")
+                    }
+                    $cmdFound
+                }
+            )
+
+            $extensionOutputs = @(foreach ($extension in $myExtensions) {
+                $extensionSplat = [Ordered]@{}
+                if ($extension.Parameters.Module) {
+                    $extensionSplat.Module = $theModule
+                }
+                & $extension @extensionSplat                
+            })
+
+            if ($extensionOutputs) {
+                foreach ($extensionOutput in $extensionOutputs) {
+                    if ($extensionOutput -is [IO.FileInfo]) {
+                        if ($extensionOutput.Extension -in '.md', '.markdown' -and $ReplaceLink) {
+                            $filesChanged += $extensionOutput
+                        } elseif ($PassThru) {
+                            $extensionOutput
+                        }                        
+                    }
+                }
+            }
+            #endregion Run Extensions to this Command
         }
 
         if ($PassThru -and $ReplaceLink) {

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -329,10 +329,10 @@
                         if ($Wiki) { $getMarkdownHelpSplat.Wiki = $Wiki}
                         else { $getMarkdownHelpSplat.GitHubDocRoot = "$($outputPath|Split-Path -Leaf)"}
                         # Call Get-MarkdownHelp, .Save it, and
-                        $markdownFile = (& $GetMarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath) |
+                        $markdownFile = (& $GetMarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath)
                             
                         $filesChanged += $markdownFile # add the file to the changed list.
-                                                    
+
                         # If -PassThru was provided (and we're not going to change anything)
                         if ($PassThru -and -not $ReplaceLink) {
                             $markdownFile # output the file changed now.

--- a/Types/PowerShell.Markdown.Help/HideSection.ps1
+++ b/Types/PowerShell.Markdown.Help/HideSection.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+    Hides sections of markdown help
+.DESCRIPTION
+    Hides sections of a command's markdown help.
+#>
+param(
+# One or more section names.
+[ValidateSet('Name','Synopsis','Description','RelatedLinks','Examples','Parameters','Inputs','Outputs','Notes','Story','Syntax')]
+[Alias('SectionName')]
+[string[]]
+$SectionNames
+)
+
+
+$skipSectionNames = @($This.HideSections)
+foreach ($SectionName in $SectionNames) {
+    if ($skipSectionNames -notcontains $SectionName) {     
+        $skipSectionNames += $SectionName 
+    }
+}
+
+$this | 
+    Add-Member NoteProperty HideSections $skipSectionNames -Force

--- a/Types/PowerShell.Markdown.Help/Save.ps1
+++ b/Types/PowerShell.Markdown.Help/Save.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Saves a Markdown Help Topic
+.DESCRIPTION
+    Saves a Markdown Help Topic to a file.
+.EXAMPLE
+    (Get-MarkdownHelp Get-MarkdownHelp).Save(".\test.md")
+.LINK
+    PowerShell.Markdown.Help.ToMarkdown
+#>
+param(
+# The path to the file.
+# If this does not exist it will be created.
+[string]
+$FilePath,
+
+# An optional view.
+# This would need to be declared in a .format.ps1xml file by another loaded module.
+[string]
+$View = 'PowerShell.Markdown.Help'
+)
+
+if (-not (Test-Path $FilePath)) {
+    $createdFile = New-Item -ItemType File -Path $FilePath -Force
+    if (-not $createdFile) { return }
+}
+
+Set-Content -Path $filePath -Value $this.ToMarkdown($view)
+
+if ($?) {
+    Get-Item -Path $FilePath
+}

--- a/Types/PowerShell.Markdown.Help/ShowSection.ps1
+++ b/Types/PowerShell.Markdown.Help/ShowSection.ps1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+    Shows sections of markdown help
+.DESCRIPTION
+    Shows sections of a command's markdown help.
+#>
+param(
+# One or more section names
+[ValidateSet('Name','Synopsis','Description','RelatedLinks','Examples','Parameters','Inputs','Outputs','Notes','Story','Syntax')]
+[Alias('SectionName')]
+[string[]]
+$SectionNames
+)
+
+$skipSectionNames = @($This.HideSections)
+foreach ($SectionName in $SectionNames) {
+    if ($skipSectionNames -contains $SectionName) {     
+        $skipSectionNames = @($skipSectionNames -ne $SectionName)
+    }
+}
+
+$this | 
+    Add-Member NoteProperty HideSections $skipSectionNames -Force
+
+

--- a/Types/PowerShell.Markdown.Help/ToMarkdown.ps1
+++ b/Types/PowerShell.Markdown.Help/ToMarkdown.ps1
@@ -1,0 +1,18 @@
+<#
+.SYNOPSIS
+    Returns this topic as a markdown string
+.DESCRIPTION
+    Returns the content of this help topic as a markdown string.
+.EXAMPLE
+
+#>
+param(
+# An optional view.
+# This would need to be declared in a .format.ps1xml file by another loaded module.
+[string]
+$View = 'PowerShell.Markdown.Help'
+)
+
+($this |
+    Format-Custom -View $View |
+    Out-String -Width 1mb).Trim()

--- a/allcommands.ps1
+++ b/allcommands.ps1
@@ -1636,13 +1636,11 @@ function Save-MarkdownHelp
                 # otherwise, pass down the parent of $OutputPath.
                 else { $getMarkdownHelpSplat.GitHubDocRoot = "$($outputPath|Split-Path -Leaf)"}
 
-                & $GetMarkdownHelp @getMarkdownHelpSplat | # Call Get-MarkdownHelp
-                    Out-String -Width 1mb                | # output it as a string
-                    ForEach-Object { $_.Trim()}          | # trim it
-                    Set-Content -Path $docOutputPath -Encoding utf8  # and set the encoding.
+                
+                $markdownFile = (Get-MarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath)
 
                 if ($PassThru) { # If -PassThru was provided, get the path.
-                    Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue
+                    $markdownFile
                 }
             }
 
@@ -1677,10 +1675,7 @@ function Save-MarkdownHelp
                     else { $getMarkdownHelpSplat.GitHubDocRoot = "$($outputPath|Split-Path -Leaf)"}
 
                     try {
-                        & $GetMarkdownHelp @getMarkdownHelpSplat | # Call Get-MarkdownHelp
-                            Out-String -Width 1mb                | # output it as a string
-                            ForEach-Object { $_.Trim()}          | # trim it
-                            Set-Content -Path $docOutputPath -Encoding utf8  # and set the encoding.
+                        $markdownFile = (Get-MarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath)                        
                     }
                     catch {
                         $ex = $_
@@ -1688,7 +1683,7 @@ function Save-MarkdownHelp
                     }
 
                     $filesChanged += # add the file to the changed list.
-                        Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue
+                        $markdownFile
 
                     # If -PassThru was provided (and we're not going to change anything)
                     if ($PassThru -and -not $ReplaceLink) {
@@ -1744,22 +1739,14 @@ function Save-MarkdownHelp
                         $getMarkdownHelpSplat.Rename = $relativePath
                         if ($Wiki) { $getMarkdownHelpSplat.Wiki = $Wiki}
                         else { $getMarkdownHelpSplat.GitHubDocRoot = "$($outputPath|Split-Path -Leaf)"}
-                        # Call Get-MarkdownHelp
-                        $markdownHelp = & $GetMarkdownHelp @getMarkdownHelpSplat |
-                            Out-String -Width 1mb # format the result
-
-                        if ($markdownHelp) {
-                            $markdownHelp.Trim() |
-                                Set-Content -Path $docOutputPath -Encoding utf8 # and save it to a file.
-                        }
-
-
-                        $filesChanged += # add the file to the changed list.
-                            Get-Item -Path $docOutputPath -ErrorAction SilentlyContinue
+                        # Call Get-MarkdownHelp, .Save it, and
+                        $markdownFile = (& $GetMarkdownHelp @getMarkdownHelpSplat).Save($docOutputPath)
+                            
+                        $filesChanged += $markdownFile # add the file to the changed list.
 
                         # If -PassThru was provided (and we're not going to change anything)
                         if ($PassThru -and -not $ReplaceLink) {
-                            $filesChanged[-1] # output the file changed now.
+                            $markdownFile # output the file changed now.
                         }
                     }
             }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,13 @@
-### 0.4.4
+### HelpOut 0.4.5:
+
+* You can now sponsor HelpOut (#126)
+* Added ScriptMethods to PowerShell.Markdown.Help (#125)
+* Now allowing Save-MarkDownHelp to be extended by any HelpOut.SaveMarkdownHelp file or function (#123)
+* Auto-documenting extended types (#101)
+
+---
+
+### HelpOut 0.4.4:
 
 * Improved HelpOut action output (Fixes #121)
 * HelpOut has a logo (Fixes #120)
@@ -6,7 +15,7 @@
 
 ---
 
-### 0.4.3
+### HelpOut 0.4.3:
 
 * Action Improvements:
   * Not obeying -InstallModule if a local module is found (Fixes #113)
@@ -15,7 +24,7 @@
 
 ---
 
-### 0.4.2
+### HelpOut 0.4.2:
 
 * Markdown Help Improvements:
   * Adding Aliases (Fixes #111)
@@ -34,15 +43,14 @@
 
 ---
 
-
-### 0.4.1
+### HelpOut 0.4.1:
 
 * Parameter Properties are now rendered as a table (Fixes #98)
 * Save-MarkdownHelp:  Adding -ExcludeFile (Fixes #97)
 
 ---
 
-### 0.4
+### HelpOut 0.4:
 
 * Get/Save-MarkdownHelp:
   * Adding -YamlHeaderInformationType and including [Reflection.AssemblyMetaData] attributes (Fixes #93)
@@ -51,52 +59,52 @@
 
 ---
 
-### 0.3.9
+### HelpOut 0.3.9:
 
 * No longer attempting to repair links if the file is not markdown (Fixes #88)
 
 ---
 
-### 0.3.8
+### HelpOut 0.3.8:
 
 * YAML Header is now optional (with -IncludeYamlHeader) (Fixes #80)
 * Save-MarkdownHelp trims content (Fixes #85)
 
 ---
 
-### 0.3.7
+### HelpOut 0.3.7:
 
 All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fixes #80)
 
 ---
 
-### 0.3.6
+### HelpOut 0.3.6:
 * Improvements to [OutputType] support (Fixes #78)
 * GitHub Action No Longer Runs when not on a branch (Fixes #77)
 
 ---
 
-### 0.3.5
+### HelpOut 0.3.5:
 * Markdown Help Improvements: Escaping Example Code (Fixes #75)
 
 ---
 
-### 0.3.4
+### HelpOut 0.3.4:
 * Fixing accidental heading names in .Link and parameter properties (Fixes #73)
 
 ---
 
-### 0.3.3
+### HelpOut 0.3.3:
 * Markdown Help now uses fewer tables (improves default GitHub Page rendering) (fixes #71)
 
 ---
 
-### 0.3.2
+### HelpOut 0.3.2:
 * Save-MarkdownHelp Bugfix (Fixes #69)
 
 ---
 
-### 0.3.1
+### HelpOut 0.3.1:
 * Save-MarkdownHelp:  
   * Can now -ReplaceLink (Fixes #66)
   * -ReplaceLink will always replace -OutputPath (Fixes #67)
@@ -104,11 +112,14 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.3:
+
+### HelpOut 0.3:
 * Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
 * Workflow improvements:  Building formatting / types in CI/CD (#63)
+
 ---
-### 0.2.9:
+
+### HelpOut 0.2.9:
 * Get-MarkdownHelp: Fixing Property Table rendering issues with ValidValues (#58)
 * Action improvements:
   * Pulling just before push (#59)
@@ -116,7 +127,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.8:
+### HelpOut 0.2.8:
 * Save-MarkdownHelp:
   * Adding -ExcludeTopic (#55)
   * -IncludeTopic excludes deeply nested topics (#54)
@@ -124,7 +135,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.7
+### HelpOut 0.2.7:
 * Save-MarkdownHelp:
   * Adding -Command, -ReplaceCommandName, -ReplaceCommandNameWith (#45)
   * Fixing -ReplaceScriptName issue (#46)
@@ -134,7 +145,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.6
+### HelpOut 0.2.6:
 * Save-MarkdownHelp:
   * Improving Inline Documentation
   * Allowing -ScriptPath to be a Regex (#41)
@@ -143,7 +154,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.5
+### HelpOut 0.2.5:
 * Save-MarkdownHelp:
   * Adding -IncludeExtension (#35)
   * Applying -PassThru to -IncludeTopic (#34)
@@ -152,7 +163,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.4
+### HelpOut 0.2.4:
 * Save-MarkdownHelp:
   * Adding -SkipCommandType (#29)
   * -ScriptPath now allows wildcards (#28)
@@ -160,7 +171,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.3
+### HelpOut 0.2.3:
 * Get/Save-MarkdownHelp:  Support for -NoValidValueEnumeration (re #25)
 * Save-MarkdownHelp:  Adding -IncludeTopic (Fixes #24, #26)
 * Adding ValidateSet/Enum Formatting for Markdown Help (Fixing #25)
@@ -168,13 +179,13 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2.2
+### HelpOut 0.2.2:
 * Fixing issue generating docs (#22)
 * HelpOut Action Fix (#20)
 
 ---
 
-### 0.2.1
+### HelpOut 0.2.1:
 * Get/Save-MarkdownHelp:  Support for -SectionOrder (#19)
 * Save-MarkdownHelp:  Adding -Passthru (#17).  Converting Markdown Help into a string (#18)
 * Get-MarkdownHelp: Returning Object (#18)
@@ -184,7 +195,7 @@ All Markdown help now includes a YAML Header unless -NoYAMLHeader is passed (Fix
 
 ---
 
-### 0.2
+### HelpOut 0.2:
 * Adding Install-MAML (#1/ #7)
 * Adding Get-MarkdownHelp (#4)
 * Adding Save-MarkdownHelp (#10)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 * You can now sponsor HelpOut (#126)
 * Added ScriptMethods to PowerShell.Markdown.Help (#125)
 * Now allowing Save-MarkDownHelp to be extended by any HelpOut.SaveMarkdownHelp file or function (#123)
-* Auto-documenting extended types (#101)
+* This is used in HelpOut.SaveMarkdownHelp.ExtendedTypes, which auto documents extended types (#101)
 
 ---
 

--- a/docs/PowerShell.Markdown.Help.HideSection.md
+++ b/docs/PowerShell.Markdown.Help.HideSection.md
@@ -13,8 +13,8 @@ Description: |
 ---
 
 
-PowerShell.Markdown.Help.HideSection
-------------------------------------
+PowerShell.Markdown.Help.HideSection()
+--------------------------------------
 
 
 
@@ -71,9 +71,3 @@ Valid Values:
 
 
 ---
-
-
-### Syntax
-```PowerShell
-PowerShell.Markdown.Help.HideSection [[-SectionNames] <String[]>] [<CommonParameters>]
-```

--- a/docs/PowerShell.Markdown.Help.HideSection.md
+++ b/docs/PowerShell.Markdown.Help.HideSection.md
@@ -1,0 +1,79 @@
+---
+CommandName: PowerShell.Markdown.Help.HideSection
+Parameters: 
+  - Name: SectionNames
+    Type: System.String[]
+    Aliases: 
+    - SectionName
+
+Synopsis: Hides sections of markdown help
+Description: |
+  
+  Hides sections of a command's markdown help.
+---
+
+
+PowerShell.Markdown.Help.HideSection
+------------------------------------
+
+
+
+
+### Synopsis
+Hides sections of markdown help
+
+
+
+---
+
+
+### Description
+
+Hides sections of a command's markdown help.
+
+
+
+---
+
+
+### Parameters
+#### **SectionNames**
+
+One or more section names.
+
+
+
+Valid Values:
+
+* Name
+* Synopsis
+* Description
+* RelatedLinks
+* Examples
+* Parameters
+* Inputs
+* Outputs
+* Notes
+* Story
+* Syntax
+
+
+
+
+
+
+|Type        |Required|Position|PipelineInput|Aliases    |
+|------------|--------|--------|-------------|-----------|
+|`[String[]]`|false   |1       |false        |SectionName|
+
+
+
+
+
+---
+
+
+### Syntax
+```PowerShell
+PowerShell.Markdown.Help.HideSection [[-SectionNames] <String[]>] [<CommonParameters>]
+```

--- a/docs/PowerShell.Markdown.Help.Save.md
+++ b/docs/PowerShell.Markdown.Help.Save.md
@@ -16,8 +16,8 @@ Description: |
 ---
 
 
-PowerShell.Markdown.Help.Save
------------------------------
+PowerShell.Markdown.Help.Save()
+-------------------------------
 
 
 
@@ -96,9 +96,3 @@ This would need to be declared in a .format.ps1xml file by another loaded module
 
 
 ---
-
-
-### Syntax
-```PowerShell
-PowerShell.Markdown.Help.Save [[-FilePath] <String>] [[-View] <String>] [<CommonParameters>]
-```

--- a/docs/PowerShell.Markdown.Help.Save.md
+++ b/docs/PowerShell.Markdown.Help.Save.md
@@ -1,0 +1,104 @@
+---
+CommandName: PowerShell.Markdown.Help.Save
+Parameters: 
+  - Name: View
+    Type: System.String
+    Aliases: 
+    
+  - Name: FilePath
+    Type: System.String
+    Aliases: 
+    
+Synopsis: Saves a Markdown Help Topic
+Description: |
+  
+  Saves a Markdown Help Topic to a file.
+---
+
+
+PowerShell.Markdown.Help.Save
+-----------------------------
+
+
+
+
+### Synopsis
+Saves a Markdown Help Topic
+
+
+
+---
+
+
+### Description
+
+Saves a Markdown Help Topic to a file.
+
+
+
+---
+
+
+### Related Links
+* PowerShell.Markdown.Help.ToMarkdown
+
+
+
+
+
+---
+
+
+### Examples
+#### EXAMPLE 1
+```PowerShell
+(Get-MarkdownHelp Get-MarkdownHelp).Save(".\test.md")
+```
+
+
+
+---
+
+
+### Parameters
+#### **FilePath**
+
+The path to the file.
+If this does not exist it will be created.
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[String]`|false   |1       |false        |
+
+
+
+#### **View**
+
+An optional view.
+This would need to be declared in a .format.ps1xml file by another loaded module.
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[String]`|false   |2       |false        |
+
+
+
+
+
+---
+
+
+### Syntax
+```PowerShell
+PowerShell.Markdown.Help.Save [[-FilePath] <String>] [[-View] <String>] [<CommonParameters>]
+```

--- a/docs/PowerShell.Markdown.Help.ShowSection.md
+++ b/docs/PowerShell.Markdown.Help.ShowSection.md
@@ -1,0 +1,79 @@
+---
+CommandName: PowerShell.Markdown.Help.ShowSection
+Parameters: 
+  - Name: SectionNames
+    Type: System.String[]
+    Aliases: 
+    - SectionName
+
+Synopsis: Shows sections of markdown help
+Description: |
+  
+  Shows sections of a command's markdown help.
+---
+
+
+PowerShell.Markdown.Help.ShowSection
+------------------------------------
+
+
+
+
+### Synopsis
+Shows sections of markdown help
+
+
+
+---
+
+
+### Description
+
+Shows sections of a command's markdown help.
+
+
+
+---
+
+
+### Parameters
+#### **SectionNames**
+
+One or more section names
+
+
+
+Valid Values:
+
+* Name
+* Synopsis
+* Description
+* RelatedLinks
+* Examples
+* Parameters
+* Inputs
+* Outputs
+* Notes
+* Story
+* Syntax
+
+
+
+
+
+
+|Type        |Required|Position|PipelineInput|Aliases    |
+|------------|--------|--------|-------------|-----------|
+|`[String[]]`|false   |1       |false        |SectionName|
+
+
+
+
+
+---
+
+
+### Syntax
+```PowerShell
+PowerShell.Markdown.Help.ShowSection [[-SectionNames] <String[]>] [<CommonParameters>]
+```

--- a/docs/PowerShell.Markdown.Help.ShowSection.md
+++ b/docs/PowerShell.Markdown.Help.ShowSection.md
@@ -13,8 +13,8 @@ Description: |
 ---
 
 
-PowerShell.Markdown.Help.ShowSection
-------------------------------------
+PowerShell.Markdown.Help.ShowSection()
+--------------------------------------
 
 
 
@@ -71,9 +71,3 @@ Valid Values:
 
 
 ---
-
-
-### Syntax
-```PowerShell
-PowerShell.Markdown.Help.ShowSection [[-SectionNames] <String[]>] [<CommonParameters>]
-```

--- a/docs/PowerShell.Markdown.Help.ToMarkdown.md
+++ b/docs/PowerShell.Markdown.Help.ToMarkdown.md
@@ -12,8 +12,8 @@ Description: |
 ---
 
 
-PowerShell.Markdown.Help.ToMarkdown
------------------------------------
+PowerShell.Markdown.Help.ToMarkdown()
+-------------------------------------
 
 
 
@@ -63,9 +63,3 @@ This would need to be declared in a .format.ps1xml file by another loaded module
 
 
 ---
-
-
-### Syntax
-```PowerShell
-PowerShell.Markdown.Help.ToMarkdown [[-View] <String>] [<CommonParameters>]
-```

--- a/docs/PowerShell.Markdown.Help.ToMarkdown.md
+++ b/docs/PowerShell.Markdown.Help.ToMarkdown.md
@@ -1,0 +1,71 @@
+---
+CommandName: PowerShell.Markdown.Help.ToMarkdown
+Parameters: 
+  - Name: View
+    Type: System.String
+    Aliases: 
+    
+Synopsis: Returns this topic as a markdown string
+Description: |
+  
+  Returns the content of this help topic as a markdown string.
+---
+
+
+PowerShell.Markdown.Help.ToMarkdown
+-----------------------------------
+
+
+
+
+### Synopsis
+Returns this topic as a markdown string
+
+
+
+---
+
+
+### Description
+
+Returns the content of this help topic as a markdown string.
+
+
+
+---
+
+
+### Examples
+#### EXAMPLE 1
+
+
+
+---
+
+
+### Parameters
+#### **View**
+
+An optional view.
+This would need to be declared in a .format.ps1xml file by another loaded module.
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[String]`|false   |1       |false        |
+
+
+
+
+
+---
+
+
+### Syntax
+```PowerShell
+PowerShell.Markdown.Help.ToMarkdown [[-View] <String>] [<CommonParameters>]
+```


### PR DESCRIPTION
### HelpOut 0.4.5:

* You can now sponsor HelpOut (#126)
* Added ScriptMethods to PowerShell.Markdown.Help (#125)
* Now allowing Save-MarkDownHelp to be extended by any HelpOut.SaveMarkdownHelp file or function (#123)
* Auto-documenting extended types (#101)

---
