### PR TITLE
HelpOut 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### HelpOut 0.4.9:
+
+* Supporting custom attribute formatting with -FormatAttribute (#147)
+  * Markdown Formatter - Honoring .FormatAttribute (#148)
+  * Get-MarkdownHelp -FormatAttribute (#149)
+  * Save-MarkdownHelp -FormatAttribute (#150)
+* Extended Type Formatting - Improving handling of empty directories (#146)
+* Updating HelpOut PSA (#152)
+
+---
+
 ### HelpOut 0.4.8:
 
 * Markdown Help Improvements:

--- a/Extensions/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
+++ b/Extensions/HelpOut.SaveMarkdownHelp.ExtendedTypes.ps1
@@ -79,6 +79,9 @@ foreach ($extendedType in $extendedTypeNames) {
         
     })
 
+    # If there were no member files, there's no point in generating a summary.
+    if (-not $memberFiles) { continue }
+
     $ExtendedTypeDocFile = Join-Path $outputPath "$(
         ($extendedType -split $punctuationNotDashOrUnderscore) -join [IO.Path]::DirectorySeparatorChar
     )$([IO.Path]::DirectorySeparatorChar)README.md"

--- a/Get-MarkdownHelp.ps1
+++ b/Get-MarkdownHelp.ps1
@@ -5,7 +5,8 @@
     .DESCRIPTION
         Gets Help for a given command, in Markdown
     .EXAMPLE
-        Get-MarkdownHelp Get-Help
+        ##### Getting Markdown Help        
+        Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help
     .LINK
         Save-MarkdownHelp
     .LINK
@@ -60,7 +61,16 @@
     [ValidateSet('Command','Help','Metadata')]
     [Alias('YamlHeaderInfoType')]
     [string[]]
-    $YamlHeaderInformationType
+    $YamlHeaderInformationType,
+
+    # The formatting used for unknown attributes.
+    # Any key or property in this object will be treated as a potential typename
+    # Any value will be the desired formatting.
+    # If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+    # If the value is a [string], it will be expanded
+    # In either context, `$_` will be the current attribute.
+    [PSObject]
+    $FormatAttribute
     )
 
     process
@@ -95,8 +105,8 @@
                         $helpObj = $_
                         # Command Help will be returned as an object
                         # We decorate that object with the typename `PowerShell.Markdown.Help`.
-                        $helpObj.pstypenames.clear()
-                        $helpObj.pstypenames.add('PowerShell.Markdown.Help')
+                        # $helpObj.pstypenames.clear()
+                        $helpObj.pstypenames.insert(0,'PowerShell.Markdown.Help')
                         $IsHelpAboutAlias = $helpObj.Name -ne $gotHelp.Name
                         $helpObj | Add-Member NoteProperty IsAlias $IsHelpAboutAlias -Force
                         if ($IsHelpAboutAlias) {
@@ -129,6 +139,9 @@
                         # * `-NoValidValueEnumeration`
                         $helpObj | Add-Member NoteProperty YamlHeaderInformationType $YamlHeaderInformationType -Force
 
+                        if ($FormatAttribute) {
+                            $helpObj | Add-Member NoteProperty FormatAttribute $FormatAttribute -Force
+                        }
 
                         # After we've attached all of the properties, we simply output the object.
                         # PowerShell.Markdown.Help formatter will display it exactly as we'd like it.                        

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -513,9 +513,45 @@ If not provided, this will be the order they are defined in the formatter.</maml
           <dev:defaultValue>
           </dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+          <maml:name>FormatAttribute</maml:name>
+          <maml:description>
+            <maml:para>The formatting used for unknown attributes.
+Any key or property in this object will be treated as a potential typename
+Any value will be the desired formatting.
+If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+If the value is a [string], it will be expanded
+In either context, `$_` will be the current attribute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="true">Psobject</command:parameterValue>
+          <dev:type>
+            <maml:name>Psobject</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>
+          </dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+        <maml:name>FormatAttribute</maml:name>
+        <maml:description>
+          <maml:para>The formatting used for unknown attributes.
+Any key or property in this object will be treated as a potential typename
+Any value will be the desired formatting.
+If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+If the value is a [string], it will be expanded
+In either context, `$_` will be the current attribute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="true">Psobject</command:parameterValue>
+        <dev:type>
+          <maml:name>Psobject</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>
+        </dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
         <maml:name>GitHubDocRoot</maml:name>
         <maml:description>
@@ -640,7 +676,8 @@ If not provided, this will be the order they are defined in the formatter.</maml
         <maml:introduction>
           <maml:para> PS &gt;  </maml:para>
         </maml:introduction>
-        <dev:code> Get-MarkdownHelp Get-Help </dev:code>
+        <dev:code> ##### Getting Markdown Help        
+Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help </dev:code>
         <dev:remarks>
         </dev:remarks>
       </command:example>

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -2043,6 +2043,24 @@ If not provided, all types of commands from the module will be saved as a markdo
           <dev:defaultValue>
           </dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+          <maml:name>FormatAttribute</maml:name>
+          <maml:description>
+            <maml:para>The formatting used for unknown attributes.
+Any key or property in this object will be treated as a potential typename
+Any value will be the desired formatting.
+If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+If the value is a [string], it will be expanded
+In either context, `$_` will be the current attribute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="true">Psobject</command:parameterValue>
+          <dev:type>
+            <maml:name>Psobject</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>
+          </dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -2083,6 +2101,24 @@ Topic files that match this pattern will not be included.</maml:para>
         <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
         <dev:type>
           <maml:name>System.String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>
+        </dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+        <maml:name>FormatAttribute</maml:name>
+        <maml:description>
+          <maml:para>The formatting used for unknown attributes.
+Any key or property in this object will be treated as a potential typename
+Any value will be the desired formatting.
+If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+If the value is a [string], it will be expanded
+In either context, `$_` will be the current attribute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="true">Psobject</command:parameterValue>
+        <dev:type>
+          <maml:name>Psobject</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -8,7 +8,7 @@
       <maml:description>
         <maml:para>Gets MAML help</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets help for a given command, as MAML (Microsoft Assistance Markup Language) xml.</maml:para>
@@ -400,7 +400,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Gets Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets Help for a given command, in Markdown</maml:para>
@@ -703,7 +703,7 @@ Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help </dev:cod
       <maml:description>
         <maml:para>Gets a script's references</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the external references of a given PowerShell command.  These are the commands the script calls, and the types the script uses.</maml:para>
@@ -829,7 +829,7 @@ Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help </dev:cod
       <maml:description>
         <maml:para>Gets a Script's story</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the Script's "Story"</maml:para>
@@ -992,7 +992,7 @@ Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help </dev:cod
       <maml:description>
         <maml:para>Installs MAML into a module</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Installs MAML into a module.  </maml:para>
@@ -1346,7 +1346,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Determines the percentage of documentation</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Determines the percentage of documentation in a given script</maml:para>
@@ -1489,7 +1489,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's MAML</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Generates a Module's MAML file, and then saves it to the appropriate location.</maml:para>
@@ -1750,7 +1750,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.4.8</dev:version>
+      <dev:version>0.4.9</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Get markdown help for each command in a module and saves it to the appropriate location.</maml:para>

--- a/HelpOut.PSA.ps1
+++ b/HelpOut.PSA.ps1
@@ -22,7 +22,7 @@ Get-BskyActorProfile -Actor $env:AT_PROTOCOL_HANDLE -Cache | Out-Host
 
 $isMergeToMain = 
     ($gitHubEvent.head_commit.message -match "Merge Pull Request #(?<PRNumber>\d+)") -and 
-    $gitHubEvent.ref -eq 'refs/heads/main'
+    $gitHubEvent.ref -in 'refs/heads/main', 'refs/heads/master'
 
 if ($isMergeToMain) {
     Import-Module .\HelpOut.psd1 -Global -PassThru | Out-Host
@@ -34,8 +34,10 @@ if ($isMergeToMain) {
         "#PowerShell people, help yourself to new bits: " |
             Get-Random        
 
-        "$moduleAndVersion is out!"
-    )    
+        "$moduleAndVersion is out!"        
+
+        "https://github.com/StartAutomating/HelpOut"
+    ) -join ([Environment]::NewLine * 2)
     
     Send-AtProto -Text $fullMessage -WebCard @{
         Url = "https://github.com/StartAutomating/HelpOut"

--- a/HelpOut.format.ps1xml
+++ b/HelpOut.format.ps1xml
@@ -112,8 +112,20 @@
             
         
 
-    $helpObject = $_
+    $helpObject      = $_
     $helpCmd         = $ExecutionContext.SessionState.InvokeCommand.GetCommand($helpObject.Name, 'All')
+    $resolvedHelpCmd =         
+        if ($helpCmd -is [Management.Automation.AliasInfo]) {
+            $resolved = helpCmd.ResolvedCommand 
+            while ($resolved.ResolvedCommand) {
+                $resolved = $resolved.ResolvedCommand 
+            }
+            $resolved 
+        } else {
+            $helpCmd
+        }
+    
+    
     $helpCmdMetadata = [Management.Automation.CommandMetadata]$helpCmd
 
     $MarkdownSections = [Ordered]@{
@@ -133,6 +145,43 @@
             &amp; ${HelpOut_Format-Markdown} -HeadingSize 3 -Heading "Description"
             foreach ($desc in $helpObject.Description) {
                 [Environment]::NewLine + $desc.text  + [Environment]::NewLine
+            }
+        }
+        CommandAttribute = {
+            
+            if (-not $helpObject.FormatAttribute) { return }
+            
+            $CmdAttributes = 
+                if ($resolvedHelpCmd.ImplementingType) {
+                    $resolvedHelpCmd.ImplementingType.GetCustomAttributes()
+                } elseif ($resolvedHelpCmd.ScriptBlock) {
+                    $resolvedHelpCmd.ScriptBlock.Attributes
+                }
+                
+            if (-not $CmdAttributes) { return }
+            
+            foreach ($attr in $CmdAttributes) {
+                $attrType = $attr.GetType()
+                $attrFormatting = 
+                    if ($helpObject.FormatAttribute.$($attrType.FullName)) {
+                        $helpObject.FormatAttribute.$($attrType.FullName)
+                    }
+                    elseif ($helpObject.FormatAttribute.$($attrType.Name)) {
+                        $helpObject.FormatAttribute.$($attrType.Name)
+                    }
+                    elseif ($helpObject.FormatAttribute.$($attrType.Name -replace 'Attribute$')) {
+                        $helpObject.FormatAttribute.$($attrType.Name -replace 'Attribute$')
+                    }
+                
+                if (-not $attrFormatting) { continue }
+                
+                $_ = $attr
+                if ($attrFormatting -is [string]) {                    
+                    $ExecutionContext.SessionState.InvokeCommand.ExpandString($attrFormatting)
+                } elseif ($attrFormatting -is [scriptblock]) {
+                    $attrFormatting | Out-Host
+                    &amp; ([ScriptBlock]::Create($attrFormatting))
+                }
             }
         }
         RelatedLinks = {
@@ -229,6 +278,29 @@
                         }
 
                     &amp; ${HelpOut_Format-Markdown} -HeadingSize 4 -Heading $parameterDisplayName
+
+                    if ($resolvedHelpCmd -and 
+                        $resolvedHelpCmd.Parameters[$parameter.Name].Attributes) {
+
+                        $paramAttributes = $resolvedHelpCmd.Parameters[$parameter.Name].Attributes
+                        foreach ($attr in $paramAttributes) {
+                            $attrType = $attr.GetType()
+                            $attrFormatting = 
+                                if ($helpObject.FormatAttribute.$($attrType.FullName)) {
+                                    $helpObject.FormatAttribute.$($attrType.FullName)
+                                }
+                                elseif ($helpObject.FormatAttribute.($attrType.Name)) {
+                                    $helpObject.FormatAttribute.($attrType.Name)
+                                }
+                            if (-not $attrFormatting) { continue }
+                            $_ = $attr
+                            if ($attrFormatting -is [string]) {                    
+                                $ExecutionContext.SessionState.InvokeCommand.ExpandString($attrFormatting)
+                            } elseif ($attrFormatting -is [scriptblock]) {
+                                . ([ScriptBlock]::Create($attrFormatting))
+                            }
+                        }
+                    }
 
                     if ($parameter.Name -in 'WhatIf', 'Confirm') {
                         "-$($parameter.Name) " +

--- a/HelpOut.psd1
+++ b/HelpOut.psd1
@@ -7,7 +7,7 @@
     ModuleToProcess='HelpOut.psm1'
     FormatsToProcess='HelpOut.format.ps1xml'
     TypesToProcess='HelpOut.types.ps1xml'
-    ModuleVersion='0.4.8'
+    ModuleVersion='0.4.9'
     PrivateData = @{
         PSData = @{
             ProjectURI = 'https://github.com/StartAutomating/HelpOut'
@@ -15,20 +15,14 @@
 
             Tags = 'Markdown', 'Help','PowerShell'
             ReleaseNotes = @'
-### HelpOut 0.4.8:
+### HelpOut 0.4.9:
 
-* Markdown Help Improvements:
-    * Fixing Long Examples (Fixes #141)
-    * Allowing first comment lines in an example to be markdown (#143)
-    * Also, switching numbered example headings to blockquotes
-* Save-MarkdownHelp updates:
-    * Fixing Piping Behavior (#140)
-    * Not Saving to illegal windows paths (#132)
-* Improving Extended Types Doc Generation
-    * Now puts extended type documentation into subfolders (#135)
-    * Also, generates a summary file for each type (#133)
-* Updating links to Microsoft modules (#142)
-* Integrating PSA into HelpOut (#144)
+* Supporting custom attribute formatting with -FormatAttribute (#147)
+  * Markdown Formatter - Honoring .FormatAttribute (#148)
+  * Get-MarkdownHelp -FormatAttribute (#149)
+  * Save-MarkdownHelp -FormatAttribute (#150)
+* Extended Type Formatting - Improving handling of empty directories (#146)
+* Updating HelpOut PSA (#152)
 
 ---
 

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -131,7 +131,16 @@
     [Parameter(ValueFromPipelineByPropertyName)]
     [Alias('SkipCommandTypes','ExcludeCommandType','ExcludeCommandTypes')]
     [Management.Automation.CommandTypes[]]
-    $SkipCommandType
+    $SkipCommandType,
+
+    # The formatting used for unknown attributes.
+    # Any key or property in this object will be treated as a potential typename
+    # Any value will be the desired formatting.
+    # If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+    # If the value is a [string], it will be expanded
+    # In either context, `$_` will be the current attribute.
+    [PSObject]
+    $FormatAttribute
     )
 
     begin {

--- a/allcommands.ps1
+++ b/allcommands.ps1
@@ -1563,7 +1563,16 @@ function Save-MarkdownHelp
     [Parameter(ValueFromPipelineByPropertyName)]
     [Alias('SkipCommandTypes','ExcludeCommandType','ExcludeCommandTypes')]
     [Management.Automation.CommandTypes[]]
-    $SkipCommandType
+    $SkipCommandType,
+
+    # The formatting used for unknown attributes.
+    # Any key or property in this object will be treated as a potential typename
+    # Any value will be the desired formatting.
+    # If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+    # If the value is a [string], it will be expanded
+    # In either context, `$_` will be the current attribute.
+    [PSObject]
+    $FormatAttribute
     )
 
     begin {

--- a/allcommands.ps1
+++ b/allcommands.ps1
@@ -408,7 +408,8 @@ function Get-MarkdownHelp {
     .DESCRIPTION
         Gets Help for a given command, in Markdown
     .EXAMPLE
-        Get-MarkdownHelp Get-Help
+        ##### Getting Markdown Help        
+        Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help
     .LINK
         Save-MarkdownHelp
     .LINK
@@ -463,7 +464,16 @@ function Get-MarkdownHelp {
     [ValidateSet('Command','Help','Metadata')]
     [Alias('YamlHeaderInfoType')]
     [string[]]
-    $YamlHeaderInformationType
+    $YamlHeaderInformationType,
+
+    # The formatting used for unknown attributes.
+    # Any key or property in this object will be treated as a potential typename
+    # Any value will be the desired formatting.
+    # If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+    # If the value is a [string], it will be expanded
+    # In either context, `$_` will be the current attribute.
+    [PSObject]
+    $FormatAttribute
     )
 
     process
@@ -498,8 +508,8 @@ function Get-MarkdownHelp {
                         $helpObj = $_
                         # Command Help will be returned as an object
                         # We decorate that object with the typename `PowerShell.Markdown.Help`.
-                        $helpObj.pstypenames.clear()
-                        $helpObj.pstypenames.add('PowerShell.Markdown.Help')
+                        # $helpObj.pstypenames.clear()
+                        $helpObj.pstypenames.insert(0,'PowerShell.Markdown.Help')
                         $IsHelpAboutAlias = $helpObj.Name -ne $gotHelp.Name
                         $helpObj | Add-Member NoteProperty IsAlias $IsHelpAboutAlias -Force
                         if ($IsHelpAboutAlias) {
@@ -532,6 +542,9 @@ function Get-MarkdownHelp {
                         # * `-NoValidValueEnumeration`
                         $helpObj | Add-Member NoteProperty YamlHeaderInformationType $YamlHeaderInformationType -Force
 
+                        if ($FormatAttribute) {
+                            $helpObj | Add-Member NoteProperty FormatAttribute $FormatAttribute -Force
+                        }
 
                         # After we've attached all of the properties, we simply output the object.
                         # PowerShell.Markdown.Help formatter will display it exactly as we'd like it.                        

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+### HelpOut 0.4.9:
+
+* Supporting custom attribute formatting with -FormatAttribute (#147)
+  * Markdown Formatter - Honoring .FormatAttribute (#148)
+  * Get-MarkdownHelp -FormatAttribute (#149)
+  * Save-MarkdownHelp -FormatAttribute (#150)
+* Extended Type Formatting - Improving handling of empty directories (#146)
+* Updating HelpOut PSA (#152)
+
+---
+
 ### HelpOut 0.4.8:
 
 * Markdown Help Improvements:

--- a/docs/Get-MarkdownHelp.md
+++ b/docs/Get-MarkdownHelp.md
@@ -5,6 +5,10 @@ Parameters:
     Type: System.String
     Aliases: 
     
+  - Name: FormatAttribute
+    Type: System.Management.Automation.PSObject
+    Aliases: 
+    
   - Name: GitHubDocRoot
     Type: System.String
     Aliases: 
@@ -85,10 +89,10 @@ Gets Help for a given command, in Markdown
 
 
 ### Examples
-> EXAMPLE 1
+#### Getting Markdown Help        
 
 ```PowerShell
-Get-MarkdownHelp Get-Help
+Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help
 ```
 
 
@@ -225,6 +229,26 @@ Valid Values:
 
 
 
+#### **FormatAttribute**
+
+The formatting used for unknown attributes.
+Any key or property in this object will be treated as a potential typename
+Any value will be the desired formatting.
+If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+If the value is a [string], it will be expanded
+In either context, `$_` will be the current attribute.
+
+
+
+
+
+
+|Type        |Required|Position|PipelineInput|
+|------------|--------|--------|-------------|
+|`[PSObject]`|false   |named   |false        |
+
+
+
 
 
 ---
@@ -259,7 +283,7 @@ How It Works
 
 
 
- Command Help will be returned as an object We decorate that object with the typename `PowerShell.Markdown.Help`.  Then we attach parameters passed to this command to the help object.  
+ Command Help will be returned as an object We decorate that object with the typename `PowerShell.Markdown.Help`.  $helpObj.pstypenames.clear() Then we attach parameters passed to this command to the help object.  
 * `-Rename` will become `[string] .Rename` 
 * `-SectionOrder` will become `[string[]] .SectionOrder` 
 * `-Wiki`  will become `[bool] .WikiLink` 
@@ -267,8 +291,6 @@ How It Works
 * `-NoValidValueEnumeration` 
 * `-IncludeYamlHeader` 
 * `-NoValidValueEnumeration`
-
-
 
  After we've attached all of the properties, we simply output the object.  PowerShell.Markdown.Help formatter will display it exactly as we'd like it.
 
@@ -278,5 +300,5 @@ How It Works
 
 ### Syntax
 ```PowerShell
-Get-MarkdownHelp [[-Name] <String>] [-Wiki] [-GitHubDocRoot <String>] [-Rename <String>] [-SectionOrder <String[]>] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [<CommonParameters>]
+Get-MarkdownHelp [[-Name] <String>] [-Wiki] [-GitHubDocRoot <String>] [-Rename <String>] [-SectionOrder <String[]>] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [-FormatAttribute <PSObject>] [<CommonParameters>]
 ```

--- a/docs/Save-MarkdownHelp.md
+++ b/docs/Save-MarkdownHelp.md
@@ -13,6 +13,10 @@ Parameters:
     Type: System.String[]
     Aliases: 
     
+  - Name: FormatAttribute
+    Type: System.Management.Automation.PSObject
+    Aliases: 
+    
   - Name: IncludeExtension
     Type: System.String[]
     Aliases: 
@@ -495,6 +499,26 @@ Valid Values:
 
 
 
+#### **FormatAttribute**
+
+The formatting used for unknown attributes.
+Any key or property in this object will be treated as a potential typename
+Any value will be the desired formatting.
+If the value is a [ScriptBlock], the [ScriptBlock] will be run.
+If the value is a [string], it will be expanded
+In either context, `$_` will be the current attribute.
+
+
+
+
+
+
+|Type        |Required|Position|PipelineInput|
+|------------|--------|--------|-------------|
+|`[PSObject]`|false   |named   |false        |
+
+
+
 
 
 ---
@@ -502,5 +526,5 @@ Valid Values:
 
 ### Syntax
 ```PowerShell
-Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-ReplaceLink <String[]>] [-ReplaceLinkWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-ExcludeFile <String[]>] [-IncludeExtension <String[]>] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [<CommonParameters>]
+Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-ReplaceLink <String[]>] [-ReplaceLinkWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-ExcludeFile <String[]>] [-IncludeExtension <String[]>] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [-FormatAttribute <PSObject>] [<CommonParameters>]
 ```


### PR DESCRIPTION
### HelpOut 0.4.9:

* Supporting custom attribute formatting with -FormatAttribute (#147)
  * Markdown Formatter - Honoring .FormatAttribute (#148)
  * Get-MarkdownHelp -FormatAttribute (#149)
  * Save-MarkdownHelp -FormatAttribute (#150)
* Extended Type Formatting - Improving handling of empty directories (#146)
* Updating HelpOut PSA (#152)

---
