### PR TITLE
HelpOut 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### HelpOut 0.5.2:
+
+* Save-MarkdownHelp:
+  * IncludeSubModule/-ExcludeSubModule ( #155 )
+  * -IncludePath ( #169 )
+  * -ExcludeFile aliases ( #168 )
+  * -ExcludeExtension ( #167 )
+  * Not Saving Files with colons ( #163 )
+
+Thanks @PrzemyslawKlys ! 
+
+---
+
 ### HelpOut 0.5.1:
 
 * Save-MarkdownHelp - -OutputPath now handles relative paths (#159)

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -2100,6 +2100,33 @@ By default, not extensions are specifically excluded.</maml:para>
           <dev:defaultValue>
           </dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+          <maml:name>IncludeSubmodule</maml:name>
+          <maml:description>
+            <maml:para>If set, will explicitly include submodule directories.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="true">Switch</command:parameterValue>
+          <dev:type>
+            <maml:name>Switch</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>
+          </dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+          <maml:name>ExcludeSubModule</maml:name>
+          <maml:description>
+            <maml:para>If set, will explicitly exclude submodule directories.
+This is the default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="true">Switch</command:parameterValue>
+          <dev:type>
+            <maml:name>Switch</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>
+          </dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" position="named" pipelineInput="True (ByPropertyName)" aliases="" variableLength="true" globbing="false">
           <maml:name>NoValidValueEnumeration</maml:name>
           <maml:description>
@@ -2217,6 +2244,20 @@ If the file name starts and ends with slashes, it will be treated as a Regular E
         </dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+        <maml:name>ExcludeSubModule</maml:name>
+        <maml:description>
+          <maml:para>If set, will explicitly exclude submodule directories.
+This is the default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="true">Switch</command:parameterValue>
+        <dev:type>
+          <maml:name>Switch</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>
+        </dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
         <maml:name>ExcludeTopic</maml:name>
         <maml:description>
           <maml:para>One or more topic file patterns to exclude.
@@ -2271,6 +2312,19 @@ If this is provided, only files that match these criteria will be included.</mam
         <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
         <dev:type>
           <maml:name>System.String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>
+        </dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+        <maml:name>IncludeSubmodule</maml:name>
+        <maml:description>
+          <maml:para>If set, will explicitly include submodule directories.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="true">Switch</command:parameterValue>
+        <dev:type>
+          <maml:name>Switch</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -2072,6 +2072,20 @@ By default, .css, .gif, .htm, .html, .js, .jpg, .jpeg, .mp4, .png, .svg</maml:pa
           <dev:defaultValue>
           </dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+          <maml:name>ExcludeExtension</maml:name>
+          <maml:description>
+            <maml:para>One or more extensions to exclude.
+By default, not extensions are specifically excluded.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>System.String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>
+          </dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" position="named" pipelineInput="True (ByPropertyName)" aliases="" variableLength="true" globbing="false">
           <maml:name>NoValidValueEnumeration</maml:name>
           <maml:description>
@@ -2154,6 +2168,20 @@ In either context, `$_` will be the current attribute.</maml:para>
         <command:parameterValue required="false" variableLength="true">System.Management.Automation.CommandInfo[]</command:parameterValue>
         <dev:type>
           <maml:name>System.Management.Automation.CommandInfo[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>
+        </dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" position="named" pipelineInput="False" aliases="" variableLength="true" globbing="false">
+        <maml:name>ExcludeExtension</maml:name>
+        <maml:description>
+          <maml:para>One or more extensions to exclude.
+By default, not extensions are specifically excluded.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="true">System.String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>System.String[]</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>

--- a/HelpOut-Help.xml
+++ b/HelpOut-Help.xml
@@ -8,7 +8,7 @@
       <maml:description>
         <maml:para>Gets MAML help</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets help for a given command, as MAML (Microsoft Assistance Markup Language) xml.</maml:para>
@@ -400,7 +400,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Gets Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets Help for a given command, in Markdown</maml:para>
@@ -703,7 +703,7 @@ Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help </dev:cod
       <maml:description>
         <maml:para>Gets a script's references</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the external references of a given PowerShell command.  These are the commands the script calls, and the types the script uses.</maml:para>
@@ -829,7 +829,7 @@ Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help </dev:cod
       <maml:description>
         <maml:para>Gets a Script's story</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Gets the Script's "Story"</maml:para>
@@ -992,7 +992,7 @@ Get-MarkdownHelp Get-Help # Get-MarkdownHelp is a wrapper for Get-Help </dev:cod
       <maml:description>
         <maml:para>Installs MAML into a module</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Installs MAML into a module.  </maml:para>
@@ -1428,7 +1428,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Determines the percentage of documentation</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Determines the percentage of documentation in a given script</maml:para>
@@ -1571,7 +1571,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's MAML</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Generates a Module's MAML file, and then saves it to the appropriate location.</maml:para>
@@ -1832,7 +1832,7 @@ This slightly reduces the size of the MAML file, and reduces the rate of changes
       <maml:description>
         <maml:para>Saves a Module's Markdown Help</maml:para>
       </maml:description>
-      <dev:version>0.5.1</dev:version>
+      <dev:version>0.5.2</dev:version>
     </command:details>
     <maml:description>
       <maml:para>Get markdown help for each command in a module and saves it to the appropriate location.</maml:para>

--- a/HelpOut.psd1
+++ b/HelpOut.psd1
@@ -1,5 +1,5 @@
 @{
-    Copyright='2019-2023 Start-Automating'
+    Copyright='2019-2024 Start-Automating'
     Description='A Helpful Toolkit for Managing PowerShell Help'
     CompanyName='Start-Automating'
     Guid='3f57070a-240f-4406-8e8e-6351ffe6f85b'
@@ -7,7 +7,7 @@
     ModuleToProcess='HelpOut.psm1'
     FormatsToProcess='HelpOut.format.ps1xml'
     TypesToProcess='HelpOut.types.ps1xml'
-    ModuleVersion='0.5.1'
+    ModuleVersion='0.5.2'
     PrivateData = @{
         PSData = @{
             ProjectURI = 'https://github.com/StartAutomating/HelpOut'
@@ -15,17 +15,21 @@
 
             Tags = 'Markdown', 'Help','PowerShell'
             ReleaseNotes = @'
-### HelpOut 0.5.1:
+### HelpOut 0.5.2:
 
-* Save-MarkdownHelp - -OutputPath now handles relative paths (#159)
-* Markdown Help Formatting - Trimming Whitespace (#161) (rendering should be unchanged)
+* Save-MarkdownHelp:
+  * IncludeSubModule/-ExcludeSubModule ( #155 )
+  * -IncludePath ( #169 )
+  * -ExcludeFile aliases ( #168 )
+  * -ExcludeExtension ( #167 )
+  * Not Saving Files with colons ( #163 )
 
-Thanks @PrzemyslawKlys ! 
+Thanks @PrzemyslawKlys !
 
 ---
 
 Additional Changes in [Changelog](/CHANGELOG.md)
-Like It?  Start It.  Love It?  Support It.
+Like It?  Star It.  Love It?  Support It.
 
 '@
         }

--- a/HelpOut.types.ps1xml
+++ b/HelpOut.types.ps1xml
@@ -61,7 +61,7 @@ $FilePath,
 $View = 'PowerShell.Markdown.Help'
 )
 
-if ($filePath -match '[\&lt;\&gt;\|\?\*]') {
+if ($filePath -match '[\&lt;\&gt;\|\?\*\:]') {
     Write-Warning "Will not .Save to $filePath, because that path will not be readable on all operating systems."
     return
 }

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -100,6 +100,7 @@
     # By default, this is treated as a wildcard.
     # If the file name starts and ends with slashes, it will be treated as a Regular Expression.
     [Parameter(ValueFromPipelineByPropertyName)]
+    [Alias('ExcludePath','ExcludeDirectory','ExcludeFolder')]
     [string[]]
     $ExcludeFile,
 

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -109,6 +109,11 @@
     [string[]]
     $IncludeExtension = @('.css','.gif', '.htm', '.html','.js', '.jpg', '.jpeg', '.mp4', '.png', '.svg'),
 
+    # One or more extensions to exclude.
+    # By default, not extensions are specifically excluded.    
+    [string[]]
+    $ExcludeExtension,
+
     # If set, will not enumerate valid values and enums of parameters.
     [Parameter(ValueFromPipelineByPropertyName)]
     [switch]
@@ -449,6 +454,13 @@
                     Where-Object $NotExcluded | # (and as long as they're not excluded)
                     ForEach-Object {
                         $fileInfo = $_
+                        if ($ExcludeExtension) {
+                            foreach ($ext in $ExcludeExtension) {
+                                if ($fileInfo.Extension -eq $ext -or $fileInfo.Extension -eq ".$ext") {
+                                    return
+                                }
+                            }
+                        }
                         foreach ($ext in $IncludeExtension) { # and see if they are the right extension
                             if ($fileInfo.Extension -eq $ext -or $fileInfo.Extension -eq ".$ext") {
                                 # Determine the relative path

--- a/Save-MarkdownHelp.ps1
+++ b/Save-MarkdownHelp.ps1
@@ -104,6 +104,13 @@
     [string[]]
     $ExcludeFile,
 
+    # A whitelist of files or directories to include.
+    # If this is provided, only files that match these criteria will be included.
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [Alias('IncludePath','IncludeDirectory','IncludeFolder')]
+    [string[]]
+    $IncludeFile,
+
     # One or more extensions to include.
     # By default, .css, .gif, .htm, .html, .js, .jpg, .jpeg, .mp4, .png, .svg
     [Parameter(ValueFromPipelineByPropertyName)]
@@ -159,6 +166,23 @@
             }
 
         $NotExcluded = {
+            if ($IncludeFile) {
+                $shouldIncludePath = 
+                    foreach ($include in $IncludeFile) {
+                        if ($include -match '^/' -and $include -match '/$') {
+                            if ([Regex]::New(
+                                $include -replace '^/' -replace '/$', 'IgnoreCase,IgnorePatternWhitespace'
+                            ).Match($_.FullName)) {
+                                $true;break
+                            }
+                        } else {
+                            if ($_.FullName -like $include -or $_.Name -like $include) {
+                                $true;break
+                            }
+                        }
+                    }
+                if (-not $shouldIncludePath) { return $false }
+            }
             if (-not $ExcludeFile) { return $true }
             foreach ($ex in $ExcludeFile) {
                 if ($ex -match '^/' -and $ex -match '/$') {

--- a/Types/PowerShell.Markdown.Help/Save.ps1
+++ b/Types/PowerShell.Markdown.Help/Save.ps1
@@ -22,7 +22,7 @@ $FilePath,
 $View = 'PowerShell.Markdown.Help'
 )
 
-if ($filePath -match '[\<\>\|\?\*]') {
+if ($filePath -match '[\<\>\|\?\*\:]') {
     Write-Warning "Will not .Save to $filePath, because that path will not be readable on all operating systems."
     return
 }

--- a/allcommands.ps1
+++ b/allcommands.ps1
@@ -1479,6 +1479,11 @@ function Save-MarkdownHelp
     [string[]]
     $IncludeExtension = @('.css','.gif', '.htm', '.html','.js', '.jpg', '.jpeg', '.mp4', '.png', '.svg'),
 
+    # One or more extensions to exclude.
+    # By default, not extensions are specifically excluded.    
+    [string[]]
+    $ExcludeExtension,
+
     # If set, will not enumerate valid values and enums of parameters.
     [Parameter(ValueFromPipelineByPropertyName)]
     [switch]
@@ -1819,6 +1824,13 @@ function Save-MarkdownHelp
                     Where-Object $NotExcluded | # (and as long as they're not excluded)
                     ForEach-Object {
                         $fileInfo = $_
+                        if ($ExcludeExtension) {
+                            foreach ($ext in $ExcludeExtension) {
+                                if ($fileInfo.Extension -eq $ext -or $fileInfo.Extension -eq ".$ext") {
+                                    return
+                                }
+                            }
+                        }
                         foreach ($ext in $IncludeExtension) { # and see if they are the right extension
                             if ($fileInfo.Extension -eq $ext -or $fileInfo.Extension -eq ".$ext") {
                                 # Determine the relative path

--- a/allcommands.ps1
+++ b/allcommands.ps1
@@ -1492,6 +1492,15 @@ function Save-MarkdownHelp
     [string[]]
     $ExcludeExtension,
 
+    # If set, will explicitly include submodule directories.
+    [switch]
+    $IncludeSubmodule,
+
+    # If set, will explicitly exclude submodule directories.
+    # This is the default.
+    [switch]
+    $ExcludeSubModule,
+
     # If set, will not enumerate valid values and enums of parameters.
     [Parameter(ValueFromPipelineByPropertyName)]
     [switch]
@@ -1583,7 +1592,7 @@ function Save-MarkdownHelp
         }
 
         $c = 0
-        $t = $Module.Count
+        $t = $Module.Count        
 
         #region Save the Markdowns
         foreach ($m in $Module) { # Walk thru the list of module names.
@@ -1611,6 +1620,25 @@ function Save-MarkdownHelp
             # If the -OutputPath does not exist
             if (-not (Test-Path $OutputPath)) {
                 $null = New-Item -ItemType Directory -Path $OutputPath # create it.
+            }
+
+            if ((-not $ExcludeSubModule) -and (-not $IncludeSubmodule)) {
+                Push-Location $theModuleRoot
+                
+                $gitCmd = $ExecutionContext.SessionState.InvokeCommand.GetCommand('git','Alias,Application')
+                $submoduleRoots = 
+                    if ($gitCmd -is [Management.Automation.AliasInfo]) {
+                        git submodule | Select-Object -ExpandProperty Submodule
+                    }
+                    else {
+                        git submodule | & { process {@($_ -split '\s')[1]} }
+                    }
+
+                if ($submoduleRoots) {
+                    $ExcludeFile += "$($pwd)$([io.path]::DirectorySeparatorChar)$submoduleRoot$([io.path]::DirectorySeparatorChar)*"
+                }
+
+                Pop-Location
             }
 
             $outputPathName = $OutputPath | Split-Path -Leaf

--- a/allcommands.ps1
+++ b/allcommands.ps1
@@ -1470,6 +1470,7 @@ function Save-MarkdownHelp
     # By default, this is treated as a wildcard.
     # If the file name starts and ends with slashes, it will be treated as a Regular Expression.
     [Parameter(ValueFromPipelineByPropertyName)]
+    [Alias('ExcludePath','ExcludeDirectory','ExcludeFolder')]
     [string[]]
     $ExcludeFile,
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+### HelpOut 0.5.2:
+
+* Save-MarkdownHelp:
+  * IncludeSubModule/-ExcludeSubModule ( #155 )
+  * -IncludePath ( #169 )
+  * -ExcludeFile aliases ( #168 )
+  * -ExcludeExtension ( #167 )
+  * Not Saving Files with colons ( #163 )
+
+Thanks @PrzemyslawKlys ! 
+
+---
+
 ### HelpOut 0.5.1:
 
 * Save-MarkdownHelp - -OutputPath now handles relative paths (#159)

--- a/docs/Save-MarkdownHelp.md
+++ b/docs/Save-MarkdownHelp.md
@@ -162,6 +162,14 @@ By default, .css, .gif, .htm, .html, .js, .jpg, .jpeg, .mp4, .png, .svg
 |------------|--------|--------|---------------------|
 |`[String[]]`|false   |named   |true (ByPropertyName)|
 
+#### **ExcludeExtension**
+One or more extensions to exclude.
+By default, not extensions are specifically excluded.
+
+|Type        |Required|Position|PipelineInput|
+|------------|--------|--------|-------------|
+|`[String[]]`|false   |named   |false        |
+
 #### **NoValidValueEnumeration**
 If set, will not enumerate valid values and enums of parameters.
 
@@ -223,5 +231,5 @@ In either context, `$_` will be the current attribute.
 
 ### Syntax
 ```PowerShell
-Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-ReplaceLink <String[]>] [-ReplaceLinkWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-ExcludeFile <String[]>] [-IncludeExtension <String[]>] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [-FormatAttribute <PSObject>] [<CommonParameters>]
+Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-ReplaceLink <String[]>] [-ReplaceLinkWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-ExcludeFile <String[]>] [-IncludeExtension <String[]>] [-ExcludeExtension <String[]>] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [-FormatAttribute <PSObject>] [<CommonParameters>]
 ```

--- a/docs/Save-MarkdownHelp.md
+++ b/docs/Save-MarkdownHelp.md
@@ -150,9 +150,9 @@ One or more files to exclude.
 By default, this is treated as a wildcard.
 If the file name starts and ends with slashes, it will be treated as a Regular Expression.
 
-|Type        |Required|Position|PipelineInput        |
-|------------|--------|--------|---------------------|
-|`[String[]]`|false   |named   |true (ByPropertyName)|
+|Type        |Required|Position|PipelineInput        |Aliases                                           |
+|------------|--------|--------|---------------------|--------------------------------------------------|
+|`[String[]]`|false   |named   |true (ByPropertyName)|ExcludePath<br/>ExcludeDirectory<br/>ExcludeFolder|
 
 #### **IncludeExtension**
 One or more extensions to include.

--- a/docs/Save-MarkdownHelp.md
+++ b/docs/Save-MarkdownHelp.md
@@ -178,6 +178,21 @@ By default, not extensions are specifically excluded.
 |------------|--------|--------|-------------|
 |`[String[]]`|false   |named   |false        |
 
+#### **IncludeSubmodule**
+If set, will explicitly include submodule directories.
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[Switch]`|false   |named   |false        |
+
+#### **ExcludeSubModule**
+If set, will explicitly exclude submodule directories.
+This is the default.
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[Switch]`|false   |named   |false        |
+
 #### **NoValidValueEnumeration**
 If set, will not enumerate valid values and enums of parameters.
 
@@ -239,5 +254,5 @@ In either context, `$_` will be the current attribute.
 
 ### Syntax
 ```PowerShell
-Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-ReplaceLink <String[]>] [-ReplaceLinkWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-ExcludeFile <String[]>] [-IncludeFile <String[]>] [-IncludeExtension <String[]>] [-ExcludeExtension <String[]>] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [-FormatAttribute <PSObject>] [<CommonParameters>]
+Save-MarkdownHelp [-Module <String[]>] [-OutputPath <String>] [-Wiki] [-Command <CommandInfo[]>] [-ReplaceCommandName <String[]>] [-ReplaceCommandNameWith <String[]>] [-ScriptPath <String[]>] [-ReplaceScriptName <String[]>] [-ReplaceScriptNameWith <String[]>] [-ReplaceLink <String[]>] [-ReplaceLinkWith <String[]>] [-PassThru] [-SectionOrder <String[]>] [-IncludeTopic <String[]>] [-ExcludeTopic <String[]>] [-ExcludeFile <String[]>] [-IncludeFile <String[]>] [-IncludeExtension <String[]>] [-ExcludeExtension <String[]>] [-IncludeSubmodule] [-ExcludeSubModule] [-NoValidValueEnumeration] [-IncludeYamlHeader] [-YamlHeaderInformationType <String[]>] [-SkipCommandType {Alias | Function | Filter | Cmdlet | ExternalScript | Application | Script | Configuration | All}] [-FormatAttribute <PSObject>] [<CommonParameters>]
 ```


### PR DESCRIPTION
### HelpOut 0.5.2:

* Save-MarkdownHelp:
  * IncludeSubModule/-ExcludeSubModule ( #155 )
  * -IncludePath ( #169 )
  * -ExcludeFile aliases ( #168 )
  * -ExcludeExtension ( #167 )
  * Not Saving Files with colons ( #163 )

