### PR TITLE
Fix #175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### HelpOut 0.5.3:
+
+* Save-MarkdownHelp:
+  * Fix saving markdown with Windows paths ( #175 )
+
+Thanks @ShaunLawrie ! 
+
+---
+
 ### HelpOut 0.5.2:
 
 * Save-MarkdownHelp:

--- a/HelpOut.psd1
+++ b/HelpOut.psd1
@@ -7,7 +7,7 @@
     ModuleToProcess='HelpOut.psm1'
     FormatsToProcess='HelpOut.format.ps1xml'
     TypesToProcess='HelpOut.types.ps1xml'
-    ModuleVersion='0.5.2'
+    ModuleVersion='0.5.3'
     PrivateData = @{
         PSData = @{
             ProjectURI = 'https://github.com/StartAutomating/HelpOut'
@@ -15,16 +15,12 @@
 
             Tags = 'Markdown', 'Help','PowerShell'
             ReleaseNotes = @'
-### HelpOut 0.5.2:
+### HelpOut 0.5.3:
 
 * Save-MarkdownHelp:
-  * IncludeSubModule/-ExcludeSubModule ( #155 )
-  * -IncludePath ( #169 )
-  * -ExcludeFile aliases ( #168 )
-  * -ExcludeExtension ( #167 )
-  * Not Saving Files with colons ( #163 )
+  * Fix saving markdown with Windows paths ( #175 )
 
-Thanks @PrzemyslawKlys !
+Thanks @ShaunLawrie ! 
 
 ---
 

--- a/HelpOut.types.ps1xml
+++ b/HelpOut.types.ps1xml
@@ -61,8 +61,13 @@ $FilePath,
 $View = 'PowerShell.Markdown.Help'
 )
 
-if ($filePath -match '[\&lt;\&gt;\|\?\*\:]') {
-    Write-Warning "Will not .Save to $filePath, because that path will not be readable on all operating systems."
+$illegalCharacters = @('&lt;', '&gt;', '|', '?', '*', ':')
+$illegalCharacterRegex = '[' + ($illegalCharacters | Foreach-Object { [regex]::Escape($_) }) + ']'
+$illegalCharacterReadable = ($illegalCharacters | Foreach-Object { "`"$_`"" }) -join ', '
+
+$filePathWithoutQualifier = Split-Path $filePath -NoQualifier
+if ($filePathWithoutQualifier -match $illegalCharacterRegex) {
+    Write-Warning "Will not .Save to $filePath, because that path will not be readable on all operating systems. It cannot contain any of the characters $illegalCharacterReadable."
     return
 }
 

--- a/Types/PowerShell.Markdown.Help/Save.ps1
+++ b/Types/PowerShell.Markdown.Help/Save.ps1
@@ -22,8 +22,13 @@ $FilePath,
 $View = 'PowerShell.Markdown.Help'
 )
 
-if ($filePath -match '[\<\>\|\?\*\:]') {
-    Write-Warning "Will not .Save to $filePath, because that path will not be readable on all operating systems."
+$illegalCharacters = @('<', '>', '|', '?', '*', ':')
+$illegalCharacterRegex = '[' + ($illegalCharacters | Foreach-Object { [regex]::Escape($_) }) + ']'
+$illegalCharacterReadable = ($illegalCharacters | Foreach-Object { "`"$_`"" }) -join ', '
+
+$filePathWithoutQualifier = Split-Path $filePath -NoQualifier
+if ($filePathWithoutQualifier -match $illegalCharacterRegex) {
+    Write-Warning "Will not .Save to $filePath, because that path will not be readable on all operating systems. It cannot contain any of the characters $illegalCharacterReadable."
     return
 }
 


### PR DESCRIPTION
Updates the warning message to explain why the path is not readable.

![image](https://github.com/StartAutomating/HelpOut/assets/13159458/545a794a-412e-4447-a639-43725b25f532)

Uses `Split-Path -NoQualifier` to validate the path excluding the drive/psdrive prefix.

Feel free to change this if you don't like the warning message formatting.